### PR TITLE
Feature#34/display stock price

### DIFF
--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -10,33 +10,39 @@ describe('workspace-project App', () => {
 
   it('should display stock price', () => {
     page.navigateToStockDetailPage('AC');
-    let stockPrice = page.getStockPrice();
+    const stockPrice = page.getStockPrice();
     // stock value
     expect(!!stockPrice).toBeTruthy(); // assures the value exists and is not 0
     expect(stockPrice).toMatch(/^\$[0-9]+(\.[0-9][0-9])?$/); // assures that the value is in format '$xxx.xx'
 
-    //stock change
-    let stockChange = page.getStockPriceChange();
-    page.getStockPriceValue().then(value =>{
+    // stock change
+    const stockChange = page.getStockPriceChange();
+    page.getStockPriceValue().then((value) => {
       let regEx;
       let expectedString;
-      if( value > 0 ) {
-        regEx = new RegExp(/^\+[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/); // assure that the value is '-xxx.xx(x.xx%)
+      if (value > 0) {
+        regEx = new RegExp(
+          /^\+[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
+        ); // assure that the value is '-xxx.xx(x.xx%)
         expectedString = 'stock-change positive-change';
       } else {
-        regEx = new RegExp(/^\-[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/);
+        regEx = new RegExp(
+          /^\-[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
+        );
         expectedString = 'stock-change negative-change';
       }
       expect(stockChange.getAttribute('class')).toBe(expectedString);
       expect(stockChange.getText()).toMatch(regEx);
-    })
-  })
+    });
+  });
 
   afterEach(async () => {
     // Assert that there are no errors emitted from the browser
     const logs = await browser.manage().logs().get(logging.Type.BROWSER);
-    expect(logs).not.toContain(jasmine.objectContaining({
-      level: logging.Level.SEVERE,
-    } as logging.Entry));
+    expect(logs).not.toContain(
+      jasmine.objectContaining({
+        level: logging.Level.SEVERE,
+      } as logging.Entry)
+    );
   });
 });

--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -8,11 +8,29 @@ describe('workspace-project App', () => {
     page = new AppPage();
   });
 
-  it('sample e2e ', () => {
-    let x = 4;
-    x += 8;
-    expect(x).toEqual(12);
-  });
+  it('should display stock price', () => {
+    page.navigateToStockDetailPage('AC');
+    let stockPrice = page.getStockPrice();
+    // stock value
+    expect(!!stockPrice).toBeTruthy(); // assures the value exists and is not 0
+    expect(stockPrice).toMatch(/^\$[0-9]+(\.[0-9][0-9])?$/); // assures that the value is in format '$xxx.xx'
+
+    //stock change
+    let stockChange = page.getStockPriceChange();
+    page.getStockPriceValue().then(value =>{
+      let regEx;
+      let expectedString;
+      if( value > 0 ) {
+        regEx = new RegExp(/^\+[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/); // assure that the value is '-xxx.xx(x.xx%)
+        expectedString = 'stock-change positive-change';
+      } else {
+        regEx = new RegExp(/^\-[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/);
+        expectedString = 'stock-change negative-change';
+      }
+      expect(stockChange.getAttribute('class')).toBe(expectedString);
+      expect(stockChange.getText()).toMatch(regEx);
+    })
+  })
 
   afterEach(async () => {
     // Assert that there are no errors emitted from the browser

--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -14,25 +14,44 @@ describe('workspace-project App', () => {
     // stock value
     expect(!!stockPrice).toBeTruthy(); // assures the value exists and is not 0
     expect(stockPrice).toMatch(/^\$[0-9]+(\.[0-9][0-9])?$/); // assures that the value is in format '$xxx.xx'
-
     // stock change
     const stockChange = page.getStockPriceChange();
+    const arrowDisplayUp = page.getArrowUp().getCssValue('display');
+    const arrowDisplayDown = page.getArrowDown().getCssValue('display');
     page.getStockPriceValue().then((value) => {
       let regEx;
       let expectedString;
+      let expectedArrowUpDisplay;
+      let expectedArrowDownDisplay;
       if (value > 0) {
         regEx = new RegExp(
           /^\+[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
         ); // assure that the value is '-xxx.xx(x.xx%)
         expectedString = 'stock-change positive-change';
-      } else {
+        expectedArrowUpDisplay = 'block';
+        expectedArrowDownDisplay = 'none';
+      }
+      else if (value === 0) {
+        regEx = new RegExp(
+          /0\(0\%\)/gm
+        ); // assure that the value is '0(0%)'
+        expectedString = 'stock-change';
+        expectedArrowUpDisplay = 'none';
+        expectedArrowDownDisplay = 'none';
+      }
+      else if (value < 0) {
         regEx = new RegExp(
           /^\-[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
         );
         expectedString = 'stock-change negative-change';
+        expectedArrowUpDisplay = 'none';
+        expectedArrowDownDisplay = 'block';
       }
       expect(stockChange.getAttribute('class')).toBe(expectedString);
       expect(stockChange.getText()).toMatch(regEx);
+      expect(arrowDisplayUp).toMatch(expectedArrowUpDisplay);
+      expect(arrowDisplayDown).toMatch(expectedArrowDownDisplay);
+
     });
   });
 

--- a/client/e2e/src/app.po.ts
+++ b/client/e2e/src/app.po.ts
@@ -1,11 +1,19 @@
-import { browser, by, element } from 'protractor';
+import { browser, by, element, ElementFinder } from 'protractor';
 
 export class AppPage {
-  navigateTo(): Promise<unknown> {
-    return browser.get(browser.baseUrl) as Promise<unknown>;
+  navigateToStockDetailPage(ticker: string): Promise<unknown> {
+    return browser.get(browser.baseUrl+"/stock-detail/"+ticker) as Promise<unknown>;
   }
 
-  getTitleText(): Promise<string> {
-    return element(by.css('app-root .content span')).getText() as Promise<string>;
+  getStockPrice(): Promise<string> {
+    return element(by.css('.stock-value')).getText() as Promise<string>;
+  }
+
+  getStockPriceValue(): Promise<number> {
+    return element(by.css('.stock-change')).getText().then(res => Number(res.replace(/[^0-9.-]+/g,""))) as Promise<number>;
+  }
+
+  getStockPriceChange(): ElementFinder {
+    return element(by.css('.stock-change'));
   }
 }

--- a/client/e2e/src/app.po.ts
+++ b/client/e2e/src/app.po.ts
@@ -2,7 +2,9 @@ import { browser, by, element, ElementFinder } from 'protractor';
 
 export class AppPage {
   navigateToStockDetailPage(ticker: string): Promise<unknown> {
-    return browser.get(browser.baseUrl+"/stock-detail/"+ticker) as Promise<unknown>;
+    return browser.get(browser.baseUrl + '/stock-detail/' + ticker) as Promise<
+      unknown
+    >;
   }
 
   getStockPrice(): Promise<string> {
@@ -10,7 +12,9 @@ export class AppPage {
   }
 
   getStockPriceValue(): Promise<number> {
-    return element(by.css('.stock-change')).getText().then(res => Number(res.replace(/[^0-9.-]+/g,""))) as Promise<number>;
+    return element(by.css('.stock-change'))
+      .getText()
+      .then((res) => Number(res.replace(/[^0-9.-]+/g, ''))) as Promise<number>;
   }
 
   getStockPriceChange(): ElementFinder {

--- a/client/e2e/src/app.po.ts
+++ b/client/e2e/src/app.po.ts
@@ -14,10 +14,17 @@ export class AppPage {
   getStockPriceValue(): Promise<number> {
     return element(by.css('.stock-change'))
       .getText()
-      .then((res) => Number(res.replace(/[^0-9.-]+/g, ''))) as Promise<number>;
+      .then((res) => Number(res.match(/^([+]|[-])?[0-9]+\.[0-9][0-9]|^0/g))) as Promise<number>;
+      // This regex matches a signed number or 0 only
   }
 
   getStockPriceChange(): ElementFinder {
     return element(by.css('.stock-change'));
+  }
+  getArrowUp(): ElementFinder {
+    return element(by.css('#up-arrow'));
+  }
+  getArrowDown(): ElementFinder {
+    return element(by.css('#down-arrow'));
   }
 }

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -546,6 +546,14 @@
         "tslib": "^2.0.0"
       }
     },
+    "@angular/flex-layout": {
+      "version": "10.0.0-beta.32",
+      "resolved": "https://registry.npmjs.org/@angular/flex-layout/-/flex-layout-10.0.0-beta.32.tgz",
+      "integrity": "sha512-JvuY4dUoy5jyCTIrFiq7n30Znakh1pD3nbg0h0hs2r3t1OiDQb0ZSI1wcumosG/vYHsuJQTuNhbfaIZzA1x8nA==",
+      "requires": {
+        "tslib": "^2.0.0"
+      }
+    },
     "@angular/forms": {
       "version": "10.1.1",
       "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-10.1.1.tgz",

--- a/client/package.json
+++ b/client/package.json
@@ -16,6 +16,7 @@
     "@angular/common": "~10.1.1",
     "@angular/compiler": "~10.1.1",
     "@angular/core": "~10.1.1",
+    "@angular/flex-layout": "^10.0.0-beta.32",
     "@angular/forms": "~10.1.1",
     "@angular/material": "^10.2.1",
     "@angular/platform-browser": "~10.1.1",

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -1,7 +1,10 @@
 import { NgModule } from '@angular/core';
 import { Routes, RouterModule } from '@angular/router';
+import { StockDetailComponent } from './pages/stock-detail/stock-detail.component';
 
-const routes: Routes = [];
+const routes: Routes = [
+  { path: 'stock-detail/:ticker', component: StockDetailComponent },
+];
 
 @NgModule({
   imports: [RouterModule.forRoot(routes)],

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -29,7 +29,7 @@ import { MatIconModule } from '@angular/material/icon';
     AppRoutingModule,
     HttpClientModule,
     BrowserAnimationsModule,
-    StoreModule.forRoot(reducer),
+    StoreModule.forRoot({appState: reducer}),
     !environment.production ? StoreDevtoolsModule.instrument() : [],
     EffectsModule.forRoot([Effects]),
     MatCardModule,

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -12,11 +12,14 @@ import { environment } from '../environments/environment';
 import { EffectsModule } from '@ngrx/effects';
 import { Effects } from './store/effects/app.effects';
 import { StockDetailComponent } from './pages/stock-detail/stock-detail.component';
+import { StockDetailHeaderComponent } from './components/stock-detail-header/stock-detail-header.component';
+import { MatCardModule } from '@angular/material/card'; 
 
 @NgModule({
   declarations: [
     AppComponent,
-    StockDetailComponent
+    StockDetailComponent,
+    StockDetailHeaderComponent
   ],
   imports: [
     BrowserModule,
@@ -25,7 +28,8 @@ import { StockDetailComponent } from './pages/stock-detail/stock-detail.componen
     BrowserAnimationsModule,
     StoreModule.forRoot(reducer),
     !environment.production ? StoreDevtoolsModule.instrument() : [],
-    EffectsModule.forRoot([Effects])
+    EffectsModule.forRoot([Effects]),
+    MatCardModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -13,8 +13,8 @@ import { EffectsModule } from '@ngrx/effects';
 import { Effects } from './store/effects/app.effects';
 import { StockDetailComponent } from './pages/stock-detail/stock-detail.component';
 import { StockDetailHeaderComponent } from './components/stock-detail-header/stock-detail-header.component';
-import { MatCardModule } from '@angular/material/card'; 
-import { FlexLayoutModule } from "@angular/flex-layout";
+import { MatCardModule } from '@angular/material/card';
+import { FlexLayoutModule } from '@angular/flex-layout';
 import { MatIconModule } from '@angular/material/icon';
 
 

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -11,10 +11,12 @@ import { StoreDevtoolsModule } from '@ngrx/store-devtools';
 import { environment } from '../environments/environment';
 import { EffectsModule } from '@ngrx/effects';
 import { Effects } from './store/effects/app.effects';
+import { StockDetailComponent } from './pages/stock-detail/stock-detail.component';
 
 @NgModule({
   declarations: [
-    AppComponent
+    AppComponent,
+    StockDetailComponent
   ],
   imports: [
     BrowserModule,

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -14,6 +14,9 @@ import { Effects } from './store/effects/app.effects';
 import { StockDetailComponent } from './pages/stock-detail/stock-detail.component';
 import { StockDetailHeaderComponent } from './components/stock-detail-header/stock-detail-header.component';
 import { MatCardModule } from '@angular/material/card'; 
+import { FlexLayoutModule } from "@angular/flex-layout";
+import { MatIconModule } from '@angular/material/icon';
+
 
 @NgModule({
   declarations: [
@@ -29,7 +32,9 @@ import { MatCardModule } from '@angular/material/card';
     StoreModule.forRoot(reducer),
     !environment.production ? StoreDevtoolsModule.instrument() : [],
     EffectsModule.forRoot([Effects]),
-    MatCardModule
+    MatCardModule,
+    FlexLayoutModule,
+    MatIconModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -1,12 +1,14 @@
 <div class="company-title">
-    <img src="https://d1yjjnpx0p53s8.cloudfront.net/styles/logo-thumbnail/s3/0021/6847/brand.gif?itok=u0iVoArk" />
-    <h1>Air Canada</h1>
+    <div class="company-logo"></div>
+    <h1><span class="ticker">AC</span> Air Canada</h1>
 </div>
 <mat-card>
-    <div >
-        ${{ stockValue }}
-        <span [ngClass]="stockChangeColor()"> {{stockInfoFormatter()}}</span>
-        
-
+    <div class="stock-pricing">
+        <span class="stock-value">${{ stockValue }}</span>
+        <span class="stock-change" [ngClass]="stockChangeColor()"> 
+            {{stockInfoFormatter()}}
+            <mat-icon id="up-arrow" aria-hidden="false">arrow_upward</mat-icon>
+            <mat-icon id="down-arrow" aria-hidden="false">arrow_downward</mat-icon>
+        </span>
     </div>
 </mat-card>

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -4,7 +4,7 @@
 </div>
 <mat-card>
     <div class="stock-pricing">
-        <span class="stock-value">${{ stockValue }}</span>
+        <span class="stock-value">${{ stockInfo.stockValue }}</span>
         <span class="stock-change" [ngClass]="stockChangeColor()"> 
             {{stockInfoFormatter()}}
             <mat-icon id="up-arrow" aria-hidden="false">arrow_upward</mat-icon>

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -4,7 +4,7 @@
 </div>
 <mat-card>
     <div class="stock-pricing">
-        <span class="stock-value">${{ stockInfo.stockValue }}</span>
+        <span class="stock-value">${{ stockValue }}</span>
         <span class="stock-change" [ngClass]="stockChangeColor()"> 
             {{stockInfoFormatter()}}
             <mat-icon id="up-arrow" aria-hidden="false">arrow_upward</mat-icon>

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -1,0 +1,11 @@
+<div class="company-title">
+    <img src="https://d1yjjnpx0p53s8.cloudfront.net/styles/logo-thumbnail/s3/0021/6847/brand.gif?itok=u0iVoArk" />
+    <h1>Air Canada</h1>
+</div>
+<mat-card>
+    <div >
+        ${{ stockValue }}
+        <span [style.color]="stockChangeColor()">+{{ stockChange }} ({{stockChangePercent}})</span>
+
+    </div>
+</mat-card>

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -5,7 +5,8 @@
 <mat-card>
     <div >
         ${{ stockValue }}
-        <span [style.color]="stockChangeColor()">+{{ stockChange }} ({{stockChangePercent}})</span>
+        <span [ngClass]="stockChangeColor()"> {{stockInfoFormatter()}}</span>
+        
 
     </div>
 </mat-card>

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
@@ -45,20 +45,25 @@
         align-items: center;
     }
 
+    #up-arrow, #down-arrow {
+        display: none;
+    }
+
     .positive-change{
         color: $mt-green;
         
-        #down-arrow {
-            display: none;
+        #up-arrow {
+            display: block;
         }
     }
     
     .negative-change{
         color: $mt-red;
         
-        #up-arrow {
-            display: none;
-        }  
+        #down-arrow {
+            display: block;
+        }
     }
+
 }
 

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
@@ -1,19 +1,64 @@
 @import '../../../styles.scss';
-img{
-    border: 1px solid black;
-    height: 60px;
-    margin-right: 15px;
-}
 
-.company-title{
+.company-title {
     display: flex;
-    align-items: baseline;
+    align-items: center;
+    margin-bottom: 20px;
+
+    h1 {
+        margin: 0;
+        font-size: 30px;
+
+        .ticker {
+            font-size: 36px;
+            text-decoration: underline;
+            color: $primary-color;
+            margin-right: 10px;
+        }
+    }
+
+    .company-logo {
+        border: 1px solid black;
+        height: 50px;
+        width: 80px;
+        background: url('https://d1yjjnpx0p53s8.cloudfront.net/styles/logo-thumbnail/s3/0021/6847/brand.gif?itok=u0iVoArk');
+        background-size: cover;
+        background-position: center;
+        margin-right: 10px;
+    }
 }
 
-.positive-change{
- color: $mt-green;   
+.stock-pricing {
+    margin-left: 1rem;
+    display: flex;
+    align-items: center;
+
+    .stock-value {
+        font-size: 24px;
+        color: $primary-color;
+        margin-right: 10px;
+    }
+
+    .stock-change {
+        font-size: 18px;
+        display: flex;
+        align-items: center;
+    }
+
+    .positive-change{
+        color: $mt-green;
+        
+        #down-arrow {
+            display: none;
+        }
+    }
+    
+    .negative-change{
+        color: $mt-red;
+        
+        #up-arrow {
+            display: none;
+        }  
+    }
 }
 
-.negative-change{
-    color: $mt-red;   
-}

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
@@ -1,0 +1,10 @@
+img{
+    border: 1px solid black;
+    height: 60px;
+    margin-right: 15px;
+}
+
+.company-title{
+    display: flex;
+    align-items: baseline;
+}

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
@@ -1,3 +1,4 @@
+@import '../../../styles.scss';
 img{
     border: 1px solid black;
     height: 60px;
@@ -7,4 +8,12 @@ img{
 .company-title{
     display: flex;
     align-items: baseline;
+}
+
+.positive-change{
+ color: $mt-green;   
+}
+
+.negative-change{
+    color: $mt-red;   
 }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StockDetailHeaderComponent } from './stock-detail-header.component';
+
+describe('StockDetailHeaderComponent', () => {
+  let component: StockDetailHeaderComponent;
+  let fixture: ComponentFixture<StockDetailHeaderComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StockDetailHeaderComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StockDetailHeaderComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -3,6 +3,7 @@ import { Stock } from '../../interfaces/stock';
 import { StockDetailHeaderComponent } from './stock-detail-header.component';
 import { MATERIAL_MODULE_DEPENDENCIES } from '../../shared.module';
 
+// integration tests
 describe('StockDetailHeaderComponent', () => {
   let component: StockDetailHeaderComponent;
   let fixture: ComponentFixture<StockDetailHeaderComponent>;
@@ -36,6 +37,7 @@ const stockInfo: Stock = {
   stockValue: 16.36,
 }
 
+// unit tests
 describe('StockDetailHeader', () => {
   let component: StockDetailHeaderComponent;
 

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -56,6 +56,8 @@ describe('StockDetailHeader', () => {
     expect(component.stockChangeColor()).toBe('positive-change');
     component.stockInfo.stockChange = -4.0;
     expect(component.stockChangeColor()).toBe('negative-change');
+    component.stockInfo.stockChange = 0;
+    expect(component.stockChangeColor()).toBe('');
     component.stockInfo = null;
     expect(component.stockChangeColor()).toBe('');
   });
@@ -65,10 +67,13 @@ describe('StockDetailHeader', () => {
     component.stockInfo.stockChange = 4.27; // needed otherwise jest rounds down to 4
     const expectedPositiveOutput = '+4.27(1.68%)';
     const expectedNegativeOuput = '-1.32(1.68%)';
-    expect(component.stockInfo.stockChange).toBe(4.27);
+    const expectedZeroOutput = '0(0%)';
     expect(component.stockInfoFormatter()).toBe(expectedPositiveOutput);
     component.stockInfo.stockChange = -1.32;
     expect(component.stockInfoFormatter()).toBe(expectedNegativeOuput);
+    component.stockInfo.stockChangePercent = 0;
+    component.stockInfo.stockChange = 0;
+    expect(component.stockInfoFormatter()).toBe(expectedZeroOutput);
     component.stockInfo = null;
     expect(component.stockInfoFormatter()).toBe('');
   });

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -1,6 +1,7 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
+import { Stock } from '../../interfaces/stock';
 import { StockDetailHeaderComponent } from './stock-detail-header.component';
+import { MATERIAL_MODULE_DEPENDENCIES } from '../../shared.module';
 
 describe('StockDetailHeaderComponent', () => {
   let component: StockDetailHeaderComponent;
@@ -8,6 +9,7 @@ describe('StockDetailHeaderComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
+      imports: MATERIAL_MODULE_DEPENDENCIES,
       declarations: [ StockDetailHeaderComponent ]
     })
     .compileComponents();
@@ -23,3 +25,50 @@ describe('StockDetailHeaderComponent', () => {
     expect(component).toBeTruthy();
   });
 });
+
+const stockInfo: Stock = {
+  tickerSymbol: 'AC',
+  companyName: 'Air Canada',
+  industry: 'Transportation',
+  volatility: 'High',
+  stockChange: 4.27,
+  stockChangePercent: 1.68,
+  stockValue: 16.36,
+}
+
+describe('StockDetailHeader', () => {
+  let component: StockDetailHeaderComponent;
+
+  beforeEach(() => {
+    component = new StockDetailHeaderComponent();
+  });
+
+  it('should display correct stock values', () => {
+    component.stockInfo = stockInfo;
+    expect(component.stockValue).toBe(component.stockInfo.stockValue);
+    component.stockInfo = null;
+    expect(component.stockValue).toBe(0);
+  })
+
+  it('should display correct stock class', () => {
+    component.stockInfo = stockInfo;
+    expect(component.stockChangeColor()).toBe('positive-change');
+    component.stockInfo.stockChange = -4.00;
+    expect(component.stockChangeColor()).toBe('negative-change');
+    component.stockInfo = null; 
+    expect(component.stockChangeColor()).toBe('');
+  })
+
+  it('should display the correct stock presentation format', () =>{
+    component.stockInfo = stockInfo;
+    component.stockInfo.stockChange = 4.27 //needed otherwise jest rounds down to 4
+    let expectedPositiveOutput = '+4.27(1.68%)';
+    let expectedNegativeOuput = '-1.32(1.68%)';
+    expect(component.stockInfo.stockChange).toBe(4.27)
+    expect(component.stockInfoFormatter()).toBe(expectedPositiveOutput);
+    component.stockInfo.stockChange = -1.32;
+    expect(component.stockInfoFormatter()).toBe(expectedNegativeOuput);
+    component.stockInfo = null;
+    expect(component.stockInfoFormatter()).toBe('');
+  })
+})

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -11,9 +11,8 @@ describe('StockDetailHeaderComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: MATERIAL_MODULE_DEPENDENCIES,
-      declarations: [ StockDetailHeaderComponent ]
-    })
-    .compileComponents();
+      declarations: [StockDetailHeaderComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {
@@ -35,7 +34,7 @@ const stockInfo: Stock = {
   stockChange: 4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
-}
+};
 
 // unit tests
 describe('StockDetailHeader', () => {
@@ -50,27 +49,27 @@ describe('StockDetailHeader', () => {
     expect(component.stockValue).toBe(component.stockInfo.stockValue);
     component.stockInfo = null;
     expect(component.stockValue).toBe(0);
-  })
+  });
 
   it('should display correct stock class', () => {
     component.stockInfo = stockInfo;
     expect(component.stockChangeColor()).toBe('positive-change');
-    component.stockInfo.stockChange = -4.00;
+    component.stockInfo.stockChange = -4.0;
     expect(component.stockChangeColor()).toBe('negative-change');
-    component.stockInfo = null; 
+    component.stockInfo = null;
     expect(component.stockChangeColor()).toBe('');
-  })
+  });
 
-  it('should display the correct stock presentation format', () =>{
+  it('should display the correct stock presentation format', () => {
     component.stockInfo = stockInfo;
-    component.stockInfo.stockChange = 4.27 //needed otherwise jest rounds down to 4
-    let expectedPositiveOutput = '+4.27(1.68%)';
-    let expectedNegativeOuput = '-1.32(1.68%)';
-    expect(component.stockInfo.stockChange).toBe(4.27)
+    component.stockInfo.stockChange = 4.27; // needed otherwise jest rounds down to 4
+    const expectedPositiveOutput = '+4.27(1.68%)';
+    const expectedNegativeOuput = '-1.32(1.68%)';
+    expect(component.stockInfo.stockChange).toBe(4.27);
     expect(component.stockInfoFormatter()).toBe(expectedPositiveOutput);
     component.stockInfo.stockChange = -1.32;
     expect(component.stockInfoFormatter()).toBe(expectedNegativeOuput);
     component.stockInfo = null;
     expect(component.stockInfoFormatter()).toBe('');
-  })
-})
+  });
+});

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -12,11 +12,19 @@ export class StockDetailHeaderComponent implements OnInit{
 
   ngOnInit(): void {}
 
-  stockChangeColor() {
-    return this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
+  get stockValue() {
+    return this.stockInfo ? this.stockInfo.stockValue : 0;
   }
+
+  stockChangeColor() {
+    return this.stockInfo && this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
+  }
+
   stockInfoFormatter() {
-    let sign = this.stockInfo.stockChange < 0 ? '-' : '+';
-    return sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)";
+    if(this.stockInfo) {
+      let sign = this.stockInfo.stockChange < 0 ? '-' : '+';
+      return sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)";
+    }
+    return '';
   }
 }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -4,27 +4,35 @@ import { Stock } from './../../interfaces/stock';
 @Component({
   selector: 'app-stock-detail-header',
   templateUrl: './stock-detail-header.component.html',
-  styleUrls: ['./stock-detail-header.component.scss']
+  styleUrls: ['./stock-detail-header.component.scss'],
 })
 export class StockDetailHeaderComponent {
   @Input() stockInfo: Stock;
-  constructor() { }
+  constructor() {}
 
-  get stockValue() {
+  get stockValue(): number {
     return this.stockInfo ? this.stockInfo.stockValue : 0;
   }
 
-  stockChangeColor() {
-    if(this.stockInfo) {
-      return this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
+  stockChangeColor(): string {
+    if (this.stockInfo) {
+      return this.stockInfo.stockChange < 0
+        ? 'negative-change'
+        : 'positive-change';
     }
     return '';
   }
 
-  stockInfoFormatter() {
-    if(this.stockInfo) {
-      let sign = this.stockInfo.stockChange < 0 ? '' : '+';
-      return (sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)");
+  stockInfoFormatter(): string {
+    if (this.stockInfo) {
+      const sign = this.stockInfo.stockChange < 0 ? '' : '+';
+      return (
+        sign +
+        this.stockInfo.stockChange +
+        '(' +
+        this.stockInfo.stockChangePercent +
+        '%)'
+      );
     }
     return '';
   }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -1,4 +1,4 @@
-import { Component, OnInit, Input } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { Stock } from './../../interfaces/stock';
 
 @Component({
@@ -6,24 +6,25 @@ import { Stock } from './../../interfaces/stock';
   templateUrl: './stock-detail-header.component.html',
   styleUrls: ['./stock-detail-header.component.scss']
 })
-export class StockDetailHeaderComponent implements OnInit{
+export class StockDetailHeaderComponent {
   @Input() stockInfo: Stock;
   constructor() { }
-
-  ngOnInit(): void {}
 
   get stockValue() {
     return this.stockInfo ? this.stockInfo.stockValue : 0;
   }
 
   stockChangeColor() {
-    return this.stockInfo && this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
+    if(this.stockInfo) {
+      return this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
+    }
+    return '';
   }
 
   stockInfoFormatter() {
     if(this.stockInfo) {
-      let sign = this.stockInfo.stockChange < 0 ? '-' : '+';
-      return sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)";
+      let sign = this.stockInfo.stockChange < 0 ? '' : '+';
+      return (sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)");
     }
     return '';
   }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -1,29 +1,22 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, Input } from '@angular/core';
+import { Stock } from './../../interfaces/stock';
 
 @Component({
   selector: 'app-stock-detail-header',
   templateUrl: './stock-detail-header.component.html',
   styleUrls: ['./stock-detail-header.component.scss']
 })
-export class StockDetailHeaderComponent implements OnInit {
-  public companyName = ""
-  public stockChange: number;
-  public stockChangePercent: number;
-  public stockValue: number;
+export class StockDetailHeaderComponent implements OnInit{
+  @Input() stockInfo: Stock;
   constructor() { }
 
-  ngOnInit(): void {
-    this.companyName = 'Air canada';
-    this.stockChange = 4.27;
-    this.stockChangePercent = 1.68;
-    this.stockValue = 16.36;
-  }
+  ngOnInit(): void {}
 
   stockChangeColor() {
-    return this.stockChange < 0 ? 'negative-change' : 'positive-change';
+    return this.stockInfo.stockChange < 0 ? 'negative-change' : 'positive-change';
   }
   stockInfoFormatter() {
-    let sign = this.stockChange < 0 ? '-' : '+';
-    return sign + this.stockChange + "("+ this.stockChangePercent+"%)";
+    let sign = this.stockInfo.stockChange < 0 ? '-' : '+';
+    return sign + this.stockInfo.stockChange + "("+ this.stockInfo.stockChangePercent+"%)";
   }
 }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -8,14 +8,14 @@ import { Stock } from './../../interfaces/stock';
 })
 export class StockDetailHeaderComponent {
   @Input() stockInfo: Stock;
-  constructor() {}
+  constructor() { }
 
   get stockValue(): number {
     return this.stockInfo ? this.stockInfo.stockValue : 0;
   }
 
   stockChangeColor(): string {
-    if (this.stockInfo) {
+    if (this.stockInfo && this.stockInfo.stockChange !== 0) {
       return this.stockInfo.stockChange < 0
         ? 'negative-change'
         : 'positive-change';
@@ -25,7 +25,7 @@ export class StockDetailHeaderComponent {
 
   stockInfoFormatter(): string {
     if (this.stockInfo) {
-      const sign = this.stockInfo.stockChange < 0 ? '' : '+';
+      const sign = this.stockInfo.stockChange <= 0 ? '' : '+';
       return (
         sign +
         this.stockInfo.stockChange +

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -13,13 +13,17 @@ export class StockDetailHeaderComponent implements OnInit {
   constructor() { }
 
   ngOnInit(): void {
-    this.companyName = "Air canada";
+    this.companyName = 'Air canada';
     this.stockChange = 4.27;
-    this.stockChangePercent = 1.68
+    this.stockChangePercent = 1.68;
     this.stockValue = 16.36;
   }
 
   stockChangeColor() {
-    return this.stockChange < 0 ? 'red' : 'green'
+    return this.stockChange < 0 ? 'negative-change' : 'positive-change';
+  }
+  stockInfoFormatter() {
+    let sign = this.stockChange < 0 ? '-' : '+';
+    return sign + this.stockChange + "("+ this.stockChangePercent+"%)";
   }
 }

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -1,0 +1,25 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-stock-detail-header',
+  templateUrl: './stock-detail-header.component.html',
+  styleUrls: ['./stock-detail-header.component.scss']
+})
+export class StockDetailHeaderComponent implements OnInit {
+  public companyName = ""
+  public stockChange: number;
+  public stockChangePercent: number;
+  public stockValue: number;
+  constructor() { }
+
+  ngOnInit(): void {
+    this.companyName = "Air canada";
+    this.stockChange = 4.27;
+    this.stockChangePercent = 1.68
+    this.stockValue = 16.36;
+  }
+
+  stockChangeColor() {
+    return this.stockChange < 0 ? 'red' : 'green'
+  }
+}

--- a/client/src/app/interfaces/stock.ts
+++ b/client/src/app/interfaces/stock.ts
@@ -3,4 +3,7 @@ export interface Stock {
     companyName: string;
     industry: string;
     volatility: string;
+    stockChange: number;
+    stockChangePercent: number;
+    stockValue: number;
 }

--- a/client/src/app/pages/stock-detail/stock-detail.component.html
+++ b/client/src/app/pages/stock-detail/stock-detail.component.html
@@ -1,0 +1,1 @@
+<p>stock-detail works!</p>

--- a/client/src/app/pages/stock-detail/stock-detail.component.html
+++ b/client/src/app/pages/stock-detail/stock-detail.component.html
@@ -1,1 +1,2 @@
 <p>stock-detail works!</p>
+<app-stock-detail-header></app-stock-detail-header>

--- a/client/src/app/pages/stock-detail/stock-detail.component.html
+++ b/client/src/app/pages/stock-detail/stock-detail.component.html
@@ -1,5 +1,5 @@
 <div class="container" fxLayout="row wrap" fxLayoutGap="16px grid">
-    <app-stock-detail-header [stockInfo]="stockInfo" fxFlex="67%" fxFlex.lt-sm="100%" ></app-stock-detail-header>
+    <app-stock-detail-header [stockInfo]="stockInfo$ | async" fxFlex="67%" fxFlex.lt-sm="100%" ></app-stock-detail-header>
     <div fxFlex="33%" fxFlex.lt-sm="100%" >side component</div>
 </div>
 

--- a/client/src/app/pages/stock-detail/stock-detail.component.html
+++ b/client/src/app/pages/stock-detail/stock-detail.component.html
@@ -1,2 +1,5 @@
-<p>stock-detail works!</p>
-<app-stock-detail-header></app-stock-detail-header>
+<div class="container" fxLayout="row wrap" fxLayoutGap="16px grid">
+    <app-stock-detail-header fxFlex="67%" fxFlex.lt-sm="100%" ></app-stock-detail-header>
+    <div fxFlex="33%" fxFlex.lt-sm="100%" >side component</div>
+</div>
+

--- a/client/src/app/pages/stock-detail/stock-detail.component.html
+++ b/client/src/app/pages/stock-detail/stock-detail.component.html
@@ -1,5 +1,5 @@
 <div class="container" fxLayout="row wrap" fxLayoutGap="16px grid">
-    <app-stock-detail-header fxFlex="67%" fxFlex.lt-sm="100%" ></app-stock-detail-header>
+    <app-stock-detail-header [stockInfo]="stockInfo" fxFlex="67%" fxFlex.lt-sm="100%" ></app-stock-detail-header>
     <div fxFlex="33%" fxFlex.lt-sm="100%" >side component</div>
 </div>
 

--- a/client/src/app/pages/stock-detail/stock-detail.component.scss
+++ b/client/src/app/pages/stock-detail/stock-detail.component.scss
@@ -1,0 +1,5 @@
+.container {
+    width: 95%;
+    margin: 0 auto !important;
+    max-width: 920px;
+}

--- a/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
@@ -1,0 +1,25 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { StockDetailComponent } from './stock-detail.component';
+
+describe('StockDetailComponent', () => {
+  let component: StockDetailComponent;
+  let fixture: ComponentFixture<StockDetailComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ StockDetailComponent ]
+    })
+    .compileComponents();
+  });
+
+  beforeEach(() => {
+    fixture = TestBed.createComponent(StockDetailComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
@@ -1,6 +1,8 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-
 import { StockDetailComponent } from './stock-detail.component';
+import { StockDetailHeaderComponent } from '../../components/stock-detail-header/stock-detail-header.component';
+import { StoreFacadeService } from '../../store/store-facade.service';
+import { MATERIAL_MODULE_DEPENDENCIES, NGRX_STORE_MODULE } from '../../shared.module';
 
 describe('StockDetailComponent', () => {
   let component: StockDetailComponent;
@@ -8,7 +10,9 @@ describe('StockDetailComponent', () => {
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ StockDetailComponent ]
+      imports: MATERIAL_MODULE_DEPENDENCIES,
+      declarations: [ StockDetailComponent, StockDetailHeaderComponent ],
+      providers: [StoreFacadeService, NGRX_STORE_MODULE]
     })
     .compileComponents();
   });

--- a/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
@@ -3,6 +3,17 @@ import { StockDetailComponent } from './stock-detail.component';
 import { StockDetailHeaderComponent } from '../../components/stock-detail-header/stock-detail-header.component';
 import { StoreFacadeService } from '../../store/store-facade.service';
 import { MATERIAL_MODULE_DEPENDENCIES, NGRX_STORE_MODULE } from '../../shared.module';
+import { ActivatedRoute } from '@angular/router';
+
+const fakeActivatedRoute = {
+  snapshot: { 
+    paramMap: {
+      get(): string {
+          return 'AC';
+      },
+    }
+  }
+} as any;
 
 describe('StockDetailComponent', () => {
   let component: StockDetailComponent;
@@ -12,7 +23,10 @@ describe('StockDetailComponent', () => {
     await TestBed.configureTestingModule({
       imports: MATERIAL_MODULE_DEPENDENCIES,
       declarations: [ StockDetailComponent, StockDetailHeaderComponent ],
-      providers: [StoreFacadeService, NGRX_STORE_MODULE]
+      providers: [
+        StoreFacadeService, 
+        {provide: ActivatedRoute, useValue: fakeActivatedRoute}, 
+        NGRX_STORE_MODULE]
     })
     .compileComponents();
   });

--- a/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.spec.ts
@@ -2,17 +2,20 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { StockDetailComponent } from './stock-detail.component';
 import { StockDetailHeaderComponent } from '../../components/stock-detail-header/stock-detail-header.component';
 import { StoreFacadeService } from '../../store/store-facade.service';
-import { MATERIAL_MODULE_DEPENDENCIES, NGRX_STORE_MODULE } from '../../shared.module';
+import {
+  MATERIAL_MODULE_DEPENDENCIES,
+  NGRX_STORE_MODULE,
+} from '../../shared.module';
 import { ActivatedRoute } from '@angular/router';
 
 const fakeActivatedRoute = {
-  snapshot: { 
+  snapshot: {
     paramMap: {
       get(): string {
-          return 'AC';
+        return 'AC';
       },
-    }
-  }
+    },
+  },
 } as any;
 
 describe('StockDetailComponent', () => {
@@ -22,13 +25,13 @@ describe('StockDetailComponent', () => {
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: MATERIAL_MODULE_DEPENDENCIES,
-      declarations: [ StockDetailComponent, StockDetailHeaderComponent ],
+      declarations: [StockDetailComponent, StockDetailHeaderComponent],
       providers: [
-        StoreFacadeService, 
-        {provide: ActivatedRoute, useValue: fakeActivatedRoute}, 
-        NGRX_STORE_MODULE]
-    })
-    .compileComponents();
+        StoreFacadeService,
+        { provide: ActivatedRoute, useValue: fakeActivatedRoute },
+        NGRX_STORE_MODULE,
+      ],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/client/src/app/pages/stock-detail/stock-detail.component.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.ts
@@ -1,0 +1,15 @@
+import { Component, OnInit } from '@angular/core';
+
+@Component({
+  selector: 'app-stock-detail',
+  templateUrl: './stock-detail.component.html',
+  styleUrls: ['./stock-detail.component.scss']
+})
+export class StockDetailComponent implements OnInit {
+
+  constructor() { }
+
+  ngOnInit(): void {
+  }
+
+}

--- a/client/src/app/pages/stock-detail/stock-detail.component.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.ts
@@ -1,4 +1,6 @@
 import { Component, OnInit } from '@angular/core';
+import { Stock } from '../../interfaces/stock';
+import { StoreFacadeService } from '../../store/store-facade.service';
 
 @Component({
   selector: 'app-stock-detail',
@@ -6,18 +8,16 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./stock-detail.component.scss']
 })
 export class StockDetailComponent implements OnInit {
-  stockInfo: Stock = {
-    tickerSymbol: 'AC',
-    companyName: 'Air Canada',
-    industry: 'Transportation',
-    volatility: 'High',
-    stockChange: 4.27,
-    stockChangePercent: 1.68,
-    stockValue: 16.36,
-  }
-  constructor() { }
+  stockInfo$ = this.storeFacade.currentStockLoaded$;
+
+  constructor(private storeFacade: StoreFacadeService) { }
 
   ngOnInit(): void {
+    this.storeFacade.loadCurrentStock('AC');
+
+    this.stockInfo$.subscribe( val =>{
+      console.log('this is the stock info', val);
+    })
   }
 
 }

--- a/client/src/app/pages/stock-detail/stock-detail.component.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.ts
@@ -6,7 +6,15 @@ import { Component, OnInit } from '@angular/core';
   styleUrls: ['./stock-detail.component.scss']
 })
 export class StockDetailComponent implements OnInit {
-
+  stockInfo: Stock = {
+    tickerSymbol: 'AC',
+    companyName: 'Air Canada',
+    industry: 'Transportation',
+    volatility: 'High',
+    stockChange: 4.27,
+    stockChangePercent: 1.68,
+    stockValue: 16.36,
+  }
   constructor() { }
 
   ngOnInit(): void {

--- a/client/src/app/pages/stock-detail/stock-detail.component.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.ts
@@ -14,10 +14,6 @@ export class StockDetailComponent implements OnInit {
 
   ngOnInit(): void {
     this.storeFacade.loadCurrentStock('AC');
-
-    this.stockInfo$.subscribe( val =>{
-      console.log('this is the stock info', val);
-    })
   }
 
 }

--- a/client/src/app/pages/stock-detail/stock-detail.component.ts
+++ b/client/src/app/pages/stock-detail/stock-detail.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
-import { Stock } from '../../interfaces/stock';
 import { StoreFacadeService } from '../../store/store-facade.service';
+import { ActivatedRoute } from '@angular/router';
 
 @Component({
   selector: 'app-stock-detail',
@@ -10,10 +10,11 @@ import { StoreFacadeService } from '../../store/store-facade.service';
 export class StockDetailComponent implements OnInit {
   stockInfo$ = this.storeFacade.currentStockLoaded$;
 
-  constructor(private storeFacade: StoreFacadeService) { }
+  constructor(private storeFacade: StoreFacadeService, private route: ActivatedRoute) { }
 
   ngOnInit(): void {
-    this.storeFacade.loadCurrentStock('AC');
+    const ticker = this.route.snapshot.paramMap.get('ticker');
+    this.storeFacade.loadCurrentStock(ticker);
   }
 
 }

--- a/client/src/app/services/stock/stock.service.ts
+++ b/client/src/app/services/stock/stock.service.ts
@@ -14,7 +14,7 @@ export class StockService {
     companyName: 'Air Canada',
     industry: 'Transportation',
     volatility: 'High',
-    stockChange: 4.27,
+    stockChange: -4.27,
     stockChangePercent: 1.68,
     stockValue: 16.36,
   }

--- a/client/src/app/services/stock/stock.service.ts
+++ b/client/src/app/services/stock/stock.service.ts
@@ -1,4 +1,6 @@
 import { Injectable } from '@angular/core';
+import { Observable, of } from 'rxjs';
+import { Stock } from 'src/app/interfaces/stock';
 import { ApiService } from '../api/api.service';
 
 @Injectable({
@@ -6,5 +8,21 @@ import { ApiService } from '../api/api.service';
 })
 export class StockService {
 
+  // To be deleted
+  stockInfo: Stock = {
+    tickerSymbol: 'AC',
+    companyName: 'Air Canada',
+    industry: 'Transportation',
+    volatility: 'High',
+    stockChange: 4.27,
+    stockChangePercent: 1.68,
+    stockValue: 16.36,
+  }
+
   constructor(private api: ApiService) { }
+
+  loadStockInfo(stockTicker: string):Observable<Stock>{
+    //http call
+    return of(this.stockInfo);
+  }
 }

--- a/client/src/app/services/stock/stock.service.ts
+++ b/client/src/app/services/stock/stock.service.ts
@@ -4,10 +4,9 @@ import { Stock } from 'src/app/interfaces/stock';
 import { ApiService } from '../api/api.service';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class StockService {
-
   // To be deleted
   stockInfo: Stock = {
     tickerSymbol: 'AC',
@@ -17,12 +16,12 @@ export class StockService {
     stockChange: -4.27,
     stockChangePercent: 1.68,
     stockValue: 16.36,
-  }
+  };
 
-  constructor(private api: ApiService) { }
+  constructor(private api: ApiService) {}
 
-  loadStockInfo(stockTicker: string):Observable<Stock>{
-    //http call
+  loadStockInfo(stockTicker: string): Observable<Stock> {
+    // http call
     return of(this.stockInfo);
   }
 }

--- a/client/src/app/shared.module.ts
+++ b/client/src/app/shared.module.ts
@@ -1,7 +1,7 @@
 // Purpose of this file is to remove annoying redundent imports from our tests
 
 import { MatIconModule } from '@angular/material/icon';
-import { MatCardModule } from '@angular/material/card'; 
+import { MatCardModule } from '@angular/material/card';
 import { initialState } from './store/reducers/app.reducer';
 import { provideMockStore } from '@ngrx/store/testing';
 
@@ -10,4 +10,4 @@ export const MATERIAL_MODULE_DEPENDENCIES = [
     MatCardModule
 ];
 
-export const NGRX_STORE_MODULE = provideMockStore({ initialState })
+export const NGRX_STORE_MODULE = provideMockStore({ initialState });

--- a/client/src/app/shared.module.ts
+++ b/client/src/app/shared.module.ts
@@ -1,0 +1,13 @@
+// Purpose of this file is to remove annoying redundent imports from our tests
+
+import { MatIconModule } from '@angular/material/icon';
+import { MatCardModule } from '@angular/material/card'; 
+import { initialState } from './store/reducers/app.reducer';
+import { provideMockStore } from '@ngrx/store/testing';
+
+export const MATERIAL_MODULE_DEPENDENCIES = [
+    MatIconModule,
+    MatCardModule
+];
+
+export const NGRX_STORE_MODULE = provideMockStore({ initialState })

--- a/client/src/app/store/actions/app.actions.spec.ts
+++ b/client/src/app/store/actions/app.actions.spec.ts
@@ -2,6 +2,6 @@ import * as fromActions from './app.actions';
 
 describe('loadActionss', () => {
   it('should return an action', () => {
-    expect(fromActions.loadActionss().type).toBe('[Actions] Load Actionss');
+    expect(fromActions.loadStockInfo({stockTicker: 'AC'}).type).toBe('[Stock Info] Load Stock Info');
   });
 });

--- a/client/src/app/store/actions/app.actions.ts
+++ b/client/src/app/store/actions/app.actions.ts
@@ -1,19 +1,5 @@
- import { createAction, props } from '@ngrx/store';
+import { createAction, props } from '@ngrx/store';
 import { Stock } from 'src/app/interfaces/stock';
-
-export const loadActionss = createAction(
-  '[Actions] Load Actionss'
-);
-
-export const loadActionssSuccess = createAction(
-  '[Actions] Load Actionss Success',
-  props<{ data: any }>()
-);
-
-export const loadActionssFailure = createAction(
-  '[Actions] Load Actionss Failure',
-  props<{ error: any }>()
-);
 
 export const loadStockInfo = createAction(
   '[Stock Info] Load Stock Info',

--- a/client/src/app/store/actions/app.actions.ts
+++ b/client/src/app/store/actions/app.actions.ts
@@ -4,9 +4,9 @@ import { Stock } from 'src/app/interfaces/stock';
 export const loadStockInfo = createAction(
   '[Stock Info] Load Stock Info',
   props<{ stockTicker: string }>()
-)
+);
 
 export const stockInfoLoadSuccess = createAction(
   '[Stock Info] Load Stock Info Success',
   props<{ stock: Stock }>()
-)
+);

--- a/client/src/app/store/actions/app.actions.ts
+++ b/client/src/app/store/actions/app.actions.ts
@@ -1,4 +1,5 @@
-import { createAction, props } from '@ngrx/store';
+ import { createAction, props } from '@ngrx/store';
+import { Stock } from 'src/app/interfaces/stock';
 
 export const loadActionss = createAction(
   '[Actions] Load Actionss'
@@ -13,3 +14,13 @@ export const loadActionssFailure = createAction(
   '[Actions] Load Actionss Failure',
   props<{ error: any }>()
 );
+
+export const loadStockInfo = createAction(
+  '[Stock Info] Load Stock Info',
+  props<{ stockTicker: string }>()
+)
+
+export const stockInfoLoadSuccess = createAction(
+  '[Stock Info] Load Stock Info Success',
+  props<{ stock: Stock }>()
+)

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -13,7 +13,7 @@ const stockInfo = {
   stockChange: -4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
-}
+};
 
 describe('Effects', () => {
   let actions$: Observable<any> = new Observable();
@@ -21,10 +21,7 @@ describe('Effects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [
-        Effects,
-        provideMockActions(() => actions$)
-      ]
+      providers: [Effects, provideMockActions(() => actions$)],
     });
 
     effects = TestBed.inject(Effects);
@@ -36,11 +33,14 @@ describe('Effects', () => {
   });
 
   // unit test
-  it('should load the data for the stock', (done) =>{ // done says that this test is asyncronous 
-    actions$ = of(appActions.loadStockInfo({stockTicker: 'AC'})); // call the action of the effect we want to test
-    effects.getStock$.subscribe((res) => { // subscribe to the observable / variable we want to test
-      expect(res['stock']).toEqual(stockInfo); // we do our assertions
+  it('should load the data for the stock', (done) => {
+    // done says that this test is asyncronous
+    actions$ = of(appActions.loadStockInfo({ stockTicker: 'AC' })); // call the action of the effect we want to test
+    effects.getStock$.subscribe((res) => {
+      // subscribe to the observable / variable we want to test
+      const key = 'stock';
+      expect(res[key]).toEqual(stockInfo); // we do our assertions
       done(); // we say that the asyncronous test is finished
-    })
-  })
+    });
+  });
 });

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -1,11 +1,22 @@
 import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
-import { Observable } from 'rxjs';
+import { Observable, of } from 'rxjs';
+import * as appActions from '../actions/app.actions';
 
 import { Effects } from './app.effects';
 
+const stockInfo = {
+  tickerSymbol: 'AC',
+  companyName: 'Air Canada',
+  industry: 'Transportation',
+  volatility: 'High',
+  stockChange: -4.27,
+  stockChangePercent: 1.68,
+  stockValue: 16.36,
+}
+
 describe('Effects', () => {
-  const actions$: Observable<any> = new Observable();
+  let actions$: Observable<any> = new Observable();
   let effects: Effects;
 
   beforeEach(() => {
@@ -18,6 +29,14 @@ describe('Effects', () => {
 
     effects = TestBed.inject(Effects);
   });
+
+  it('should load the data for the stock', (done) =>{
+    actions$ = of(appActions.loadStockInfo({stockTicker: 'AC'}));
+    effects.getStock$.subscribe((res) => {
+      expect(res['stock']).toEqual(stockInfo);
+      done();
+    })
+  })
 
   it('should be created', () => {
     expect(effects).toBeTruthy();

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -30,15 +30,17 @@ describe('Effects', () => {
     effects = TestBed.inject(Effects);
   });
 
-  it('should load the data for the stock', (done) =>{
-    actions$ = of(appActions.loadStockInfo({stockTicker: 'AC'}));
-    effects.getStock$.subscribe((res) => {
-      expect(res['stock']).toEqual(stockInfo);
-      done();
-    })
-  })
-
+  // integration test
   it('should be created', () => {
     expect(effects).toBeTruthy();
   });
+
+  // unit test
+  it('should load the data for the stock', (done) =>{ // done says that this test is asyncronous 
+    actions$ = of(appActions.loadStockInfo({stockTicker: 'AC'})); // call the action of the effect we want to test
+    effects.getStock$.subscribe((res) => { // subscribe to the observable / variable we want to test
+      expect(res['stock']).toEqual(stockInfo); // we do our assertions
+      done(); // we say that the asyncronous test is finished
+    })
+  })
 });

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -10,21 +10,23 @@ import { map, switchMap } from 'rxjs/operators';
 
 @Injectable()
 export class Effects {
-
-  constructor(private actions$: Actions,
+  constructor(
+    private actions$: Actions,
     private stockService: StockService,
     private transactionService: TransactionService,
-    private userService: UserService) { }
+    private userService: UserService
+  ) {}
 
   getStock$: Observable<Action> = createEffect(() =>
     this.actions$.pipe(
       ofType(appActions.loadStockInfo),
-      switchMap(action =>{
-        return this.stockService.loadStockInfo(action.stockTicker).pipe(
-          map((data) => appActions.stockInfoLoadSuccess({stock: data}))
-        )
+      switchMap((action) => {
+        return this.stockService
+          .loadStockInfo(action.stockTicker)
+          .pipe(
+            map((data) => appActions.stockInfoLoadSuccess({ stock: data }))
+          );
       })
     )
-  )
-
+  );
 }

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -1,20 +1,15 @@
 import { Injectable } from '@angular/core';
 import { Observable, of } from 'rxjs';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
-import { Action, props } from '@ngrx/store';
+import { Action } from '@ngrx/store';
 import { StockService } from '../../services/stock/stock.service';
 import { TransactionService } from '../../services/transaction/transaction.service';
 import { UserService } from '../../services/user/user.service';
 import * as appActions from '../actions/app.actions';
-import { map, mergeMap, switchMap } from 'rxjs/operators';
-
-
-
+import { map, switchMap } from 'rxjs/operators';
 
 @Injectable()
 export class Effects {
-
-
 
   constructor(private actions$: Actions,
     private stockService: StockService,

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
 import { Actions, createEffect, ofType } from '@ngrx/effects';
 import { Action } from '@ngrx/store';
 import { StockService } from '../../services/stock/stock.service';

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -1,8 +1,13 @@
 import { Injectable } from '@angular/core';
-import { Actions, createEffect } from '@ngrx/effects';
+import { Observable, of } from 'rxjs';
+import { Actions, createEffect, ofType } from '@ngrx/effects';
+import { Action, props } from '@ngrx/store';
 import { StockService } from '../../services/stock/stock.service';
 import { TransactionService } from '../../services/transaction/transaction.service';
 import { UserService } from '../../services/user/user.service';
+import * as appActions from '../actions/app.actions';
+import { map, mergeMap, switchMap } from 'rxjs/operators';
+
 
 
 
@@ -12,8 +17,19 @@ export class Effects {
 
 
   constructor(private actions$: Actions,
-              private stockService: StockService,
-              private transactionService: TransactionService,
-              private userService: UserService) {}
+    private stockService: StockService,
+    private transactionService: TransactionService,
+    private userService: UserService) { }
+
+  getStock$: Observable<Action> = createEffect(() =>
+    this.actions$.pipe(
+      ofType(appActions.loadStockInfo),
+      switchMap(action =>{
+        return this.stockService.loadStockInfo(action.stockTicker).pipe(
+          map((data) => appActions.stockInfoLoadSuccess({stock: data}))
+        )
+      })
+    )
+  )
 
 }

--- a/client/src/app/store/reducers/app.reducer.spec.ts
+++ b/client/src/app/store/reducers/app.reducer.spec.ts
@@ -10,7 +10,7 @@ const stockInfo: Stock = {
   stockChange: -4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
-}
+};
 
 describe('Reducer Reducer', () => {
   describe('an unknown action', () => {
@@ -21,9 +21,9 @@ describe('Reducer Reducer', () => {
     });
 
     it('should return the state with loaded stock', () => {
-      const action = appActions.stockInfoLoadSuccess({stock: stockInfo});
+      const action = appActions.stockInfoLoadSuccess({ stock: stockInfo });
       const state = reducer(initialState, action);
       expect(state.currentStockLoaded).toEqual(stockInfo);
-    })
+    });
   });
 });

--- a/client/src/app/store/reducers/app.reducer.spec.ts
+++ b/client/src/app/store/reducers/app.reducer.spec.ts
@@ -1,13 +1,29 @@
 import { reducer, initialState } from './app.reducer';
+import * as appActions from '../actions/app.actions';
+import { Stock } from '../../interfaces/stock';
+
+const stockInfo: Stock = {
+  tickerSymbol: 'AC',
+  companyName: 'Air Canada',
+  industry: 'Transportation',
+  volatility: 'High',
+  stockChange: -4.27,
+  stockChangePercent: 1.68,
+  stockValue: 16.36,
+}
 
 describe('Reducer Reducer', () => {
   describe('an unknown action', () => {
     it('should return the previous state', () => {
       const action = {} as any;
-
       const result = reducer(initialState, action);
-
       expect(result).toBe(initialState);
     });
+
+    it('should return the state with loaded stock', () => {
+      const action = appActions.stockInfoLoadSuccess({stock: stockInfo});
+      const state = reducer(initialState, action);
+      expect(state.currentStockLoaded).toEqual(stockInfo);
+    })
   });
 });

--- a/client/src/app/store/reducers/app.reducer.ts
+++ b/client/src/app/store/reducers/app.reducer.ts
@@ -3,7 +3,6 @@ import { Stock } from 'src/app/interfaces/stock';
 import { User } from 'src/app/interfaces/user';
 import * as appActions from '../actions/app.actions';
 
-
 export const reducerFeatureKey = 'reducer';
 
 export interface State {
@@ -15,7 +14,6 @@ export const initialState: State = {
   user: null,
   currentStockLoaded: null,
 };
-
 
 export const reducer = createReducer(
   initialState,

--- a/client/src/app/store/reducers/app.reducer.ts
+++ b/client/src/app/store/reducers/app.reducer.ts
@@ -1,20 +1,24 @@
 import { Action, createReducer, on } from '@ngrx/store';
+import { Stock } from 'src/app/interfaces/stock';
 import { User } from 'src/app/interfaces/user';
+import * as appActions from '../actions/app.actions';
 
 
 export const reducerFeatureKey = 'reducer';
 
 export interface State {
   user: User;
+  currentStockLoaded: Stock;
 }
 
 export const initialState: State = {
-  user: null
+  user: null,
+  currentStockLoaded: null,
 };
 
 
 export const reducer = createReducer(
   initialState,
-
+  on(appActions.stockInfoLoadSuccess, (state, {stock}) => ({...state, currentStockLoaded: stock}))
 );
 

--- a/client/src/app/store/reducers/app.reducer.ts
+++ b/client/src/app/store/reducers/app.reducer.ts
@@ -1,4 +1,4 @@
-import { Action, createReducer, on } from '@ngrx/store';
+import { createReducer, on } from '@ngrx/store';
 import { Stock } from 'src/app/interfaces/stock';
 import { User } from 'src/app/interfaces/user';
 import * as appActions from '../actions/app.actions';

--- a/client/src/app/store/selectors/app.selectors.spec.ts
+++ b/client/src/app/store/selectors/app.selectors.spec.ts
@@ -10,15 +10,15 @@ const stockInfo: Stock = {
   stockChange: -4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
-}
+};
 
 describe('Selectors', () => {
   it('should select the currently loaded stock', () => {
-    let appState = appReducers.initialState;
+    const appState = appReducers.initialState;
     appState.currentStockLoaded = stockInfo;
-    // we have our selector (selectCurrentStock) 
+    // we have our selector (selectCurrentStock)
     // we pass in the state we want to test it with (appState)
-    // we look for the result (stockInfo) 
-    expect(appSelectors.selectCurrentStock.projector(appState)).toBe(stockInfo)
+    // we look for the result (stockInfo)
+    expect(appSelectors.selectCurrentStock.projector(appState)).toBe(stockInfo);
   });
 });

--- a/client/src/app/store/selectors/app.selectors.spec.ts
+++ b/client/src/app/store/selectors/app.selectors.spec.ts
@@ -15,7 +15,10 @@ const stockInfo: Stock = {
 describe('Selectors', () => {
   it('should select the currently loaded stock', () => {
     let appState = appReducers.initialState;
-    appState.currentStockLoaded = stockInfo
+    appState.currentStockLoaded = stockInfo;
+    // we have our selector (selectCurrentStock) 
+    // we pass in the state we want to test it with (appState)
+    // we look for the result (stockInfo) 
     expect(appSelectors.selectCurrentStock.projector(appState)).toBe(stockInfo)
   });
 });

--- a/client/src/app/store/selectors/app.selectors.spec.ts
+++ b/client/src/app/store/selectors/app.selectors.spec.ts
@@ -1,7 +1,21 @@
+import * as appSelectors from '../selectors/app.selectors';
+import * as appReducers from '../reducers/app.reducer';
+import { Stock } from '../../interfaces/stock';
 
+const stockInfo: Stock = {
+  tickerSymbol: 'AC',
+  companyName: 'Air Canada',
+  industry: 'Transportation',
+  volatility: 'High',
+  stockChange: -4.27,
+  stockChangePercent: 1.68,
+  stockValue: 16.36,
+}
 
-describe('Selector Selectors', () => {
-  it('should select the feature state', () => {
-
+describe('Selectors', () => {
+  it('should select the currently loaded stock', () => {
+    let appState = appReducers.initialState;
+    appState.currentStockLoaded = stockInfo
+    expect(appSelectors.selectCurrentStock.projector(appState)).toBe(stockInfo)
   });
 });

--- a/client/src/app/store/selectors/app.selectors.ts
+++ b/client/src/app/store/selectors/app.selectors.ts
@@ -1,2 +1,5 @@
 import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { State } from '../reducers/app.reducer';
+import { Stock } from 'src/app/interfaces/stock';
 
+export const selectLoadedStock = (state: State) => state.currentStockLoaded;

--- a/client/src/app/store/selectors/app.selectors.ts
+++ b/client/src/app/store/selectors/app.selectors.ts
@@ -1,5 +1,14 @@
-import { createFeatureSelector, createSelector } from '@ngrx/store';
+import { createSelector } from '@ngrx/store';
 import { State } from '../reducers/app.reducer';
 import { Stock } from 'src/app/interfaces/stock';
 
-export const selectLoadedStock = (state: State) => state.currentStockLoaded;
+interface appState {
+    appState: State
+}
+
+export const selectAppState = (data: appState) => data.appState;
+
+export const selectCurrentStock = createSelector(
+    selectAppState,
+    (appState: State) => appState.currentStockLoaded
+)

--- a/client/src/app/store/selectors/app.selectors.ts
+++ b/client/src/app/store/selectors/app.selectors.ts
@@ -1,14 +1,13 @@
 import { createSelector } from '@ngrx/store';
 import { State } from '../reducers/app.reducer';
-import { Stock } from 'src/app/interfaces/stock';
 
-interface appState {
-    appState: State
+interface AppState {
+  appState: State;
 }
 
-export const selectAppState = (data: appState) => data.appState;
+export const selectAppState = (data: AppState) => data.appState;
 
 export const selectCurrentStock = createSelector(
-    selectAppState,
-    (appState: State) => appState.currentStockLoaded
-)
+  selectAppState,
+  (appState: State) => appState.currentStockLoaded
+);

--- a/client/src/app/store/store-facade.service.spec.ts
+++ b/client/src/app/store/store-facade.service.spec.ts
@@ -10,7 +10,7 @@ describe('StoreFacadeService', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      providers: [NGRX_STORE_MODULE]
+      providers: [NGRX_STORE_MODULE],
     });
 
     store = TestBed.inject(MockStore);
@@ -23,12 +23,12 @@ describe('StoreFacadeService', () => {
   });
 
   // unit test
-  it('should dispatch load stock action', () =>{
+  it('should dispatch load stock action', () => {
     const spy = jest.spyOn(store, 'dispatch');
     service.loadCurrentStock('TESLA');
     expect(spy).toHaveBeenCalled();
     expect(spy).toHaveBeenCalledWith(
-      appActions.loadStockInfo({stockTicker: 'TESLA'})
-    )
-  })
+      appActions.loadStockInfo({ stockTicker: 'TESLA' })
+    );
+  });
 });

--- a/client/src/app/store/store-facade.service.spec.ts
+++ b/client/src/app/store/store-facade.service.spec.ts
@@ -1,14 +1,30 @@
 import { TestBed } from '@angular/core/testing';
-
+import { MockStore } from '@ngrx/store/testing';
 import { StoreFacadeService } from './store-facade.service';
+import * as appActions from './actions/app.actions';
+import { NGRX_STORE_MODULE } from '../shared.module';
 
 describe('StoreFacadeService', () => {
   let service: StoreFacadeService;
+  let store: MockStore;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      providers: [NGRX_STORE_MODULE]
+    });
+
+    store = TestBed.inject(MockStore);
     service = TestBed.inject(StoreFacadeService);
   });
+
+  it('should dispatch load stock action', () =>{
+    const spy = jest.spyOn(store, 'dispatch');
+    service.loadCurrentStock('AC');
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      appActions.loadStockInfo({stockTicker: 'AC'})
+    )
+  })
 
   it('should be created', () => {
     expect(service).toBeTruthy();

--- a/client/src/app/store/store-facade.service.spec.ts
+++ b/client/src/app/store/store-facade.service.spec.ts
@@ -17,16 +17,18 @@ describe('StoreFacadeService', () => {
     service = TestBed.inject(StoreFacadeService);
   });
 
-  it('should dispatch load stock action', () =>{
-    const spy = jest.spyOn(store, 'dispatch');
-    service.loadCurrentStock('AC');
-    expect(spy).toHaveBeenCalled();
-    expect(spy).toHaveBeenCalledWith(
-      appActions.loadStockInfo({stockTicker: 'AC'})
-    )
-  })
-
+  // integration test
   it('should be created', () => {
     expect(service).toBeTruthy();
   });
+
+  // unit test
+  it('should dispatch load stock action', () =>{
+    const spy = jest.spyOn(store, 'dispatch');
+    service.loadCurrentStock('TESLA');
+    expect(spy).toHaveBeenCalled();
+    expect(spy).toHaveBeenCalledWith(
+      appActions.loadStockInfo({stockTicker: 'TESLA'})
+    )
+  })
 });

--- a/client/src/app/store/store-facade.service.ts
+++ b/client/src/app/store/store-facade.service.ts
@@ -7,16 +7,18 @@ import { Observable } from 'rxjs';
 import { Stock } from '../interfaces/stock';
 
 @Injectable({
-  providedIn: 'root'
+  providedIn: 'root',
 })
 export class StoreFacadeService {
   currentStockLoaded$: Observable<Stock>;
-  
-  constructor(private store: Store<{appState: State}>) { 
-    this.currentStockLoaded$ = this.store.select(appSelectors.selectCurrentStock);
+
+  constructor(private store: Store<{ appState: State }>) {
+    this.currentStockLoaded$ = this.store.select(
+      appSelectors.selectCurrentStock
+    );
   }
 
-  loadCurrentStock(ticker: string) {
-    this.store.dispatch(appActions.loadStockInfo({stockTicker: ticker}));
+  loadCurrentStock(ticker: string): void {
+    this.store.dispatch(appActions.loadStockInfo({ stockTicker: ticker }));
   }
 }

--- a/client/src/app/store/store-facade.service.ts
+++ b/client/src/app/store/store-facade.service.ts
@@ -1,9 +1,19 @@
 import { Injectable } from '@angular/core';
+import { Store } from '@ngrx/store';
+import { State } from './reducers/app.reducer';
+import * as appActions from './actions/app.actions';
+import * as appSelectors from './selectors/app.selectors';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StoreFacadeService {
+  currentStockLoaded$ = this.store.select(appSelectors.selectLoadedStock);
 
-  constructor() { }
+  constructor(private store: Store<State>) { }
+
+  loadCurrentStock(ticker: string) {
+    console.log("load current stock");
+    this.store.dispatch(appActions.loadStockInfo({stockTicker: ticker}));
+  }
 }

--- a/client/src/app/store/store-facade.service.ts
+++ b/client/src/app/store/store-facade.service.ts
@@ -3,17 +3,20 @@ import { Store } from '@ngrx/store';
 import { State } from './reducers/app.reducer';
 import * as appActions from './actions/app.actions';
 import * as appSelectors from './selectors/app.selectors';
+import { Observable } from 'rxjs';
+import { Stock } from '../interfaces/stock';
 
 @Injectable({
   providedIn: 'root'
 })
 export class StoreFacadeService {
-  currentStockLoaded$ = this.store.select(appSelectors.selectLoadedStock);
-
-  constructor(private store: Store<State>) { }
+  currentStockLoaded$: Observable<Stock>;
+  
+  constructor(private store: Store<{appState: State}>) { 
+    this.currentStockLoaded$ = this.store.select(appSelectors.selectCurrentStock);
+  }
 
   loadCurrentStock(ticker: string) {
-    console.log("load current stock");
     this.store.dispatch(appActions.loadStockInfo({stockTicker: ticker}));
   }
 }

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -37,3 +37,8 @@ $client-theme: mat-light-theme((
 
 html, body { height: 100%; }
 body { margin: 0; font-family: Roboto, "Helvetica Neue", sans-serif; }
+
+$primary-color: #07367C;
+$mt-green: #338641;
+$mt-red: #C42126;
+

--- a/client/tsconfig.spec.json
+++ b/client/tsconfig.spec.json
@@ -5,7 +5,7 @@
     "outDir": "./out-tsc/spec",
     "emitDecoratorMetadata": true,
     "types": [
-      "jasmine"
+      "jest"
     ]
   },
   "files": [


### PR DESCRIPTION
 
# Related Issue
- [#34](https://github.com/DPigeon/Money-Tree/issues/34) 

# Proposed changes
- Created stock-detail page
- Displayed hard coded data of stock information

# Additional Info
- This PR takes care of everything frontend related to this story. There will be a follow up story that will link this aspect with real values coming from real life 

# Checklist (if applicable)
- [X] Tests
- [X] Documentation

# Screenshots (if applicable)
<img width="761" alt="Screen Shot 2020-11-04 at 3 51 35 PM" src="https://user-images.githubusercontent.com/18631060/98166578-a4ef6b80-1eb5-11eb-9828-988ed134a3de.png">

# Reviewer(s)
 - @arthur-del 
 - @marwan011 
 - @EspressoCode 
