### PR TITLE
Feature/get stock price information #111

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -16,5 +16,5 @@ alpaca.base.data.url=https://data.alpaca.markets
 alpaca.user.agent=MoneyTree_api_v1
 
 # IEXCloud related properties
-IEXCloud.publishable.token=pk_8a16faf2696d4bde96405d7ec55bc581
-IEXCloud.secret.token=sk_82b8015588e94a6f89ff37ea41137212
+IEXCloud.publishable.token=pk_a91bb5a4faf6401da964db6bd96d087e
+IEXCloud.secret.token=sk_25c6140713724699acd73260f29154c0

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerTest.groovy
@@ -11,8 +11,8 @@ import spock.lang.Specification
 
 class StockControllerTest extends Specification {
 
-    private static final String PUBLISH_TOKEN = "pk_8a16faf2696d4bde96405d7ec55bc581"
-    private static final String SECRET_TOKEN = "sk_82b8015588e94a6f89ff37ea41137212"
+    private static final String PUBLISH_TOKEN = "pk_a91bb5a4faf6401da964db6bd96d087e"
+    private static final String SECRET_TOKEN = "sk_25c6140713724699acd73260f29154c0"
 
     StockMarketDataFacade stockMarketDataFacade = new StockMarketDataFacade(PUBLISH_TOKEN, SECRET_TOKEN)
     StockMarketDataService stockMarketDataService = new DefaultStockMarketDataService(stockMarketDataFacade: stockMarketDataFacade)

--- a/client/angular.json
+++ b/client/angular.json
@@ -57,7 +57,7 @@
                 {
                   "type": "anyComponentStyle",
                   "maximumWarning": "6kb",
-                  "maximumError": "10kb"
+                  "maximumError": "1000kb"
                 }
               ]
             }

--- a/client/e2e/protractor.conf.js
+++ b/client/e2e/protractor.conf.js
@@ -13,7 +13,10 @@ exports.config = {
     './src/**/*.e2e-spec.ts'
   ],
   capabilities: {
-    browserName: 'chrome'
+    browserName: 'chrome',
+    'chromeOptions': {
+      'args': ['--disable-web-security', '--user-data-dir=~/.e2e-chrome-profile']
+    }
   },
   directConnect: true,
   baseUrl: 'http://localhost:4200/',

--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -9,7 +9,7 @@ describe('workspace-project App', () => {
   });
 
   it('should display stock price', () => {
-    page.navigateToStockDetailPage('AC');
+    page.navigateToStockDetailPage('AAPL');
     const stockPrice = page.getStockPrice();
     // stock value
     expect(!!stockPrice).toBeTruthy(); // assures the value exists and is not 0
@@ -30,18 +30,14 @@ describe('workspace-project App', () => {
         expectedString = 'stock-change positive-change';
         expectedArrowUpDisplay = 'block';
         expectedArrowDownDisplay = 'none';
-      }
-      else if (value === 0) {
-        regEx = new RegExp(
-          /0\\s(0\%\)/gm
-        ); // assure that the value is '0 (0%)'
+      } else if (value === 0) {
+        regEx = new RegExp(/0\s\(0\%\)/gm); // assure that the value is '0 (0%)'
         expectedString = 'stock-change';
         expectedArrowUpDisplay = 'none';
         expectedArrowDownDisplay = 'none';
-      }
-      else if (value < 0) {
+      } else if (value < 0) {
         regEx = new RegExp(
-          /^\-[0-9]+(\.[0-9][0-9])?\s\([0-9]+(\.[0-9][0-9])?\%\)/
+          /^\-[0-9]+(\.[0-9][0-9])?\s\(-[0-9]+(\.[0-9][0-9])?\%\)/
         );
         expectedString = 'stock-change negative-change';
         expectedArrowUpDisplay = 'none';
@@ -51,7 +47,6 @@ describe('workspace-project App', () => {
       expect(stockChange.getText()).toMatch(regEx);
       expect(arrowDisplayUp).toMatch(expectedArrowUpDisplay);
       expect(arrowDisplayDown).toMatch(expectedArrowDownDisplay);
-
     });
   });
 

--- a/client/e2e/src/app.e2e-spec.ts
+++ b/client/e2e/src/app.e2e-spec.ts
@@ -25,23 +25,23 @@ describe('workspace-project App', () => {
       let expectedArrowDownDisplay;
       if (value > 0) {
         regEx = new RegExp(
-          /^\+[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
-        ); // assure that the value is '-xxx.xx(x.xx%)
+          /^\+[0-9]+(\.[0-9][0-9])?\s\([0-9]+(\.[0-9][0-9])?\%\)/
+        ); // assure that the value is '-xxx.xx (x.xx%)
         expectedString = 'stock-change positive-change';
         expectedArrowUpDisplay = 'block';
         expectedArrowDownDisplay = 'none';
       }
       else if (value === 0) {
         regEx = new RegExp(
-          /0\(0\%\)/gm
-        ); // assure that the value is '0(0%)'
+          /0\\s(0\%\)/gm
+        ); // assure that the value is '0 (0%)'
         expectedString = 'stock-change';
         expectedArrowUpDisplay = 'none';
         expectedArrowDownDisplay = 'none';
       }
       else if (value < 0) {
         regEx = new RegExp(
-          /^\-[0-9]+(\.[0-9][0-9])?\([0-9]+(\.[0-9][0-9])?\%\)/
+          /^\-[0-9]+(\.[0-9][0-9])?\s\([0-9]+(\.[0-9][0-9])?\%\)/
         );
         expectedString = 'stock-change negative-change';
         expectedArrowUpDisplay = 'none';

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.html
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.html
@@ -1,6 +1,6 @@
 <div class="company-title">
-    <div class="company-logo"></div>
-    <h1><span class="ticker">AC</span> Air Canada</h1>
+    <div class="company-logo" [style.background-image]='companyLogo'></div>
+    <h1><span class="ticker">{{ companySymbol }}</span> {{ companyName }}</h1>
 </div>
 <mat-card>
     <div class="stock-pricing">

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.scss
@@ -21,7 +21,6 @@
         border: 1px solid black;
         height: 50px;
         width: 80px;
-        background: url('https://d1yjjnpx0p53s8.cloudfront.net/styles/logo-thumbnail/s3/0021/6847/brand.gif?itok=u0iVoArk');
         background-size: cover;
         background-position: center;
         margin-right: 10px;

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -34,6 +34,7 @@ const stockInfo: Stock = {
   stockChange: 4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
+  logo: 'https://d1yjjnpx0p53s8.cloudfront.net/styles/logo-thumbnail/s3/0021/6847/brand.gif?itok=u0iVoArk'
 };
 
 // unit tests
@@ -65,9 +66,9 @@ describe('StockDetailHeader', () => {
   it('should display the correct stock presentation format', () => {
     component.stockInfo = stockInfo;
     component.stockInfo.stockChange = 4.27; // needed otherwise jest rounds down to 4
-    const expectedPositiveOutput = '+4.27(1.68%)';
-    const expectedNegativeOuput = '-1.32(1.68%)';
-    const expectedZeroOutput = '0(0%)';
+    const expectedPositiveOutput = '+4.27 (1.68%)';
+    const expectedNegativeOuput = '-1.32 (1.68%)';
+    const expectedZeroOutput = '0 (0.00%)';
     expect(component.stockInfoFormatter()).toBe(expectedPositiveOutput);
     component.stockInfo.stockChange = -1.32;
     expect(component.stockInfoFormatter()).toBe(expectedNegativeOuput);

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.spec.ts
@@ -47,9 +47,9 @@ describe('StockDetailHeader', () => {
 
   it('should display correct stock values', () => {
     component.stockInfo = stockInfo;
-    expect(component.stockValue).toBe(component.stockInfo.stockValue);
+    expect(component.stockValue).toBe(component.stockInfo.stockValue.toFixed(2));
     component.stockInfo = null;
-    expect(component.stockValue).toBe(0);
+    expect(component.stockValue).toBe('');
   });
 
   it('should display correct stock class', () => {
@@ -68,7 +68,7 @@ describe('StockDetailHeader', () => {
     component.stockInfo.stockChange = 4.27; // needed otherwise jest rounds down to 4
     const expectedPositiveOutput = '+4.27 (1.68%)';
     const expectedNegativeOuput = '-1.32 (1.68%)';
-    const expectedZeroOutput = '0 (0.00%)';
+    const expectedZeroOutput = '0.00 (0.00%)';
     expect(component.stockInfoFormatter()).toBe(expectedPositiveOutput);
     component.stockInfo.stockChange = -1.32;
     expect(component.stockInfoFormatter()).toBe(expectedNegativeOuput);

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -22,8 +22,8 @@ export class StockDetailHeaderComponent {
     return this.stockInfo ? this.stockInfo.companyName : '';
   }
 
-  get stockValue(): number {
-    return this.stockInfo ? this.stockInfo.stockValue : 0;
+  get stockValue(): string {
+    return this.stockInfo ? this.stockInfo.stockValue.toFixed(2) : '';
   }
 
   stockChangeColor(): string {
@@ -40,7 +40,7 @@ export class StockDetailHeaderComponent {
       const sign = this.stockInfo.stockChange <= 0 ? '' : '+';
       return (
         sign +
-        this.stockInfo.stockChange +
+        this.stockInfo.stockChange.toFixed(2) +
         ' (' +
         this.stockInfo.stockChangePercent.toFixed(2) +
         '%)'

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -8,17 +8,17 @@ import { Stock } from './../../interfaces/stock';
 })
 export class StockDetailHeaderComponent {
   @Input() stockInfo: Stock;
-  constructor() { }
+  constructor() {}
 
   get companyLogo(): string {
-    return this.stockInfo ? 'url(' + this.stockInfo.logo +')': '';
+    return this.stockInfo ? 'url(' + this.stockInfo.logo + ')' : '';
   }
 
   get companySymbol(): string {
     return this.stockInfo ? this.stockInfo.tickerSymbol : '';
   }
 
-  get companyName(): string{
+  get companyName(): string {
     return this.stockInfo ? this.stockInfo.companyName : '';
   }
 

--- a/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
+++ b/client/src/app/components/stock-detail-header/stock-detail-header.component.ts
@@ -10,6 +10,18 @@ export class StockDetailHeaderComponent {
   @Input() stockInfo: Stock;
   constructor() { }
 
+  get companyLogo(): string {
+    return this.stockInfo ? 'url(' + this.stockInfo.logo +')': '';
+  }
+
+  get companySymbol(): string {
+    return this.stockInfo ? this.stockInfo.tickerSymbol : '';
+  }
+
+  get companyName(): string{
+    return this.stockInfo ? this.stockInfo.companyName : '';
+  }
+
   get stockValue(): number {
     return this.stockInfo ? this.stockInfo.stockValue : 0;
   }
@@ -29,8 +41,8 @@ export class StockDetailHeaderComponent {
       return (
         sign +
         this.stockInfo.stockChange +
-        '(' +
-        this.stockInfo.stockChangePercent +
+        ' (' +
+        this.stockInfo.stockChangePercent.toFixed(2) +
         '%)'
       );
     }

--- a/client/src/app/interfaces/stock.ts
+++ b/client/src/app/interfaces/stock.ts
@@ -6,4 +6,5 @@ export interface Stock {
     stockChange: number;
     stockChangePercent: number;
     stockValue: number;
+    logo: string;
 }

--- a/client/src/app/services/api/api.service.spec.ts
+++ b/client/src/app/services/api/api.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ApiService } from './api.service';
 
 describe('ApiService', () => {
   let service: ApiService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(ApiService);
   });
 

--- a/client/src/app/services/api/api.service.ts
+++ b/client/src/app/services/api/api.service.ts
@@ -1,9 +1,17 @@
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
+import { Observable } from 'rxjs';
 
 @Injectable({
   providedIn: 'root'
 })
 export class ApiService {
 
-  constructor() { }
+  baseUrl = 'http://localhost:8080/api/';
+
+  constructor(private http: HttpClient) { }
+
+  get(url: string): Observable<any> {
+    return this.http.get(this.baseUrl + url);
+  }
 }

--- a/client/src/app/services/stock/stock.service.spec.ts
+++ b/client/src/app/services/stock/stock.service.spec.ts
@@ -1,6 +1,7 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StockService } from './stock.service';
+import { Stock } from 'src/app/interfaces/stock';
 
 describe('StockService', () => {
   let service: StockService;
@@ -12,7 +13,42 @@ describe('StockService', () => {
     service = TestBed.inject(StockService);
   });
 
+  // integration test
   it('should be created', () => {
     expect(service).toBeTruthy();
+  });
+
+  const iexSampleResponse = {
+    company: {
+      symbol: 'AC',
+      companyName: 'Air Canada',
+      industry: 'Travel'
+    },
+    book: {
+      quote: {
+        change: 4,
+        changePercent: 0.03,
+        latestPrice: 16.34
+      }
+    },
+    logo: {
+      url: 'sampleurl'
+    }
+  }
+
+  const expectedStock: Stock ={
+    tickerSymbol: iexSampleResponse.company.symbol,
+    companyName: iexSampleResponse.company.companyName,
+    industry: iexSampleResponse.company.industry,
+    volatility: 'low',
+    stockChange: iexSampleResponse.book.quote.change,
+    stockChangePercent: iexSampleResponse.book.quote.changePercent *100,
+    stockValue: iexSampleResponse.book.quote.latestPrice,
+    logo: iexSampleResponse.logo.url,
+  }
+
+  it('should convert iex data to frontend model', () =>{
+    const transformedData = service.IEXtoModel(iexSampleResponse);
+    expect(transformedData).toEqual(expectedStock);
   });
 });

--- a/client/src/app/services/stock/stock.service.spec.ts
+++ b/client/src/app/services/stock/stock.service.spec.ts
@@ -22,32 +22,32 @@ describe('StockService', () => {
     company: {
       symbol: 'AC',
       companyName: 'Air Canada',
-      industry: 'Travel'
+      industry: 'Travel',
     },
     book: {
       quote: {
         change: 4,
         changePercent: 0.03,
-        latestPrice: 16.34
-      }
+        latestPrice: 16.34,
+      },
     },
     logo: {
-      url: 'sampleurl'
-    }
-  }
+      url: 'sampleurl',
+    },
+  };
 
-  const expectedStock: Stock ={
+  const expectedStock: Stock = {
     tickerSymbol: iexSampleResponse.company.symbol,
     companyName: iexSampleResponse.company.companyName,
     industry: iexSampleResponse.company.industry,
     volatility: 'low',
     stockChange: iexSampleResponse.book.quote.change,
-    stockChangePercent: iexSampleResponse.book.quote.changePercent *100,
+    stockChangePercent: iexSampleResponse.book.quote.changePercent * 100,
     stockValue: iexSampleResponse.book.quote.latestPrice,
     logo: iexSampleResponse.logo.url,
-  }
+  };
 
-  it('should convert iex data to frontend model', () =>{
+  it('should convert iex data to frontend model', () => {
     const transformedData = service.IEXtoModel(iexSampleResponse);
     expect(transformedData).toEqual(expectedStock);
   });

--- a/client/src/app/services/stock/stock.service.spec.ts
+++ b/client/src/app/services/stock/stock.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { StockService } from './stock.service';
 
 describe('StockService', () => {
   let service: StockService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(StockService);
   });
 

--- a/client/src/app/services/stock/stock.service.ts
+++ b/client/src/app/services/stock/stock.service.ts
@@ -1,5 +1,6 @@
 import { Injectable } from '@angular/core';
-import { Observable, of } from 'rxjs';
+import { Observable } from 'rxjs';
+import { map } from 'rxjs/operators';
 import { Stock } from 'src/app/interfaces/stock';
 import { ApiService } from '../api/api.service';
 
@@ -7,21 +8,26 @@ import { ApiService } from '../api/api.service';
   providedIn: 'root',
 })
 export class StockService {
-  // To be deleted
-  stockInfo: Stock = {
-    tickerSymbol: 'AC',
-    companyName: 'Air Canada',
-    industry: 'Transportation',
-    volatility: 'High',
-    stockChange: -4.27,
-    stockChangePercent: 1.68,
-    stockValue: 16.36,
-  };
-
   constructor(private api: ApiService) {}
 
   loadStockInfo(stockTicker: string): Observable<Stock> {
-    // http call
-    return of(this.stockInfo);
+    return this.api
+      .get('stockmarket/batch/' + stockTicker.toUpperCase())
+      .pipe(map((res: any) => this.IEXtoModel(res)));
+  }
+
+  // This will need to be discussed: formatting responses frontend vs backend, same models?
+  IEXtoModel(iex: any): Stock {
+    let stock: Stock = {
+      tickerSymbol: iex.company.symbol,
+      companyName: iex.company.companyName,
+      industry: iex.company.industry,
+      volatility: 'low',
+      stockChange: iex.book.quote.change,
+      stockChangePercent: iex.book.quote.changePercent * 100,
+      stockValue: iex.book.quote.latestPrice,
+      logo: iex.logo.url,
+    };
+    return stock;
   }
 }

--- a/client/src/app/services/stock/stock.service.ts
+++ b/client/src/app/services/stock/stock.service.ts
@@ -18,7 +18,7 @@ export class StockService {
 
   // This will need to be discussed: formatting responses frontend vs backend, same models?
   IEXtoModel(iex: any): Stock {
-    let stock: Stock = {
+    const stock: Stock = {
       tickerSymbol: iex.company.symbol,
       companyName: iex.company.companyName,
       industry: iex.company.industry,

--- a/client/src/app/services/transaction/transaction.service.spec.ts
+++ b/client/src/app/services/transaction/transaction.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { TransactionService } from './transaction.service';
 
 describe('TransactionService', () => {
   let service: TransactionService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(TransactionService);
   });
 

--- a/client/src/app/services/user/user.service.spec.ts
+++ b/client/src/app/services/user/user.service.spec.ts
@@ -1,12 +1,14 @@
 import { TestBed } from '@angular/core/testing';
-
 import { UserService } from './user.service';
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 
 describe('UserService', () => {
   let service: UserService;
 
   beforeEach(() => {
-    TestBed.configureTestingModule({});
+    TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
+    });
     service = TestBed.inject(UserService);
   });
 

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -2,7 +2,7 @@ import { TestBed } from '@angular/core/testing';
 import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import * as appActions from '../actions/app.actions';
-
+import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Effects } from './app.effects';
 
 const stockInfo = {
@@ -21,6 +21,7 @@ describe('Effects', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
+      imports: [HttpClientTestingModule],
       providers: [Effects, provideMockActions(() => actions$)],
     });
 
@@ -36,6 +37,7 @@ describe('Effects', () => {
   it('should load the data for the stock', (done) => {
     // done says that this test is asyncronous
     actions$ = of(appActions.loadStockInfo({ stockTicker: 'AC' })); // call the action of the effect we want to test
+    
     effects.getStock$.subscribe((res) => {
       // subscribe to the observable / variable we want to test
       const key = 'stock';

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -19,17 +19,17 @@ const stockInfo = {
 describe('Effects', () => {
   let actions$: Observable<any> = new Observable();
   let effects: Effects;
-  let mockStockService = {
-    loadStockInfo: jest.fn(()=> of(stockInfo))
+  const mockStockService = {
+    loadStockInfo: jest.fn(() => of(stockInfo)),
   };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
       providers: [
-        Effects, 
+        Effects,
         provideMockActions(() => actions$),
-        {provide: StockService, useValue: mockStockService}
+        { provide: StockService, useValue: mockStockService },
       ],
     });
 
@@ -45,7 +45,7 @@ describe('Effects', () => {
   it('should load the data for the stock', (done) => {
     // done says that this test is asyncronous
     actions$ = of(appActions.loadStockInfo({ stockTicker: 'AC' })); // call the action of the effect we want to test
-    
+
     effects.getStock$.subscribe((res) => {
       // subscribe to the observable / variable we want to test
       const key = 'stock';

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -3,6 +3,7 @@ import { provideMockActions } from '@ngrx/effects/testing';
 import { Observable, of } from 'rxjs';
 import * as appActions from '../actions/app.actions';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
+import { StockService } from '../../services/stock/stock.service';
 import { Effects } from './app.effects';
 
 const stockInfo = {
@@ -18,11 +19,18 @@ const stockInfo = {
 describe('Effects', () => {
   let actions$: Observable<any> = new Observable();
   let effects: Effects;
+  let mockStockService = {
+    loadStockInfo: jest.fn(()=> of(stockInfo))
+  };
 
   beforeEach(() => {
     TestBed.configureTestingModule({
       imports: [HttpClientTestingModule],
-      providers: [Effects, provideMockActions(() => actions$)],
+      providers: [
+        Effects, 
+        provideMockActions(() => actions$),
+        {provide: StockService, useValue: mockStockService}
+      ],
     });
 
     effects = TestBed.inject(Effects);

--- a/client/src/app/store/reducers/app.reducer.spec.ts
+++ b/client/src/app/store/reducers/app.reducer.spec.ts
@@ -10,6 +10,7 @@ const stockInfo: Stock = {
   stockChange: -4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
+  logo: ''
 };
 
 describe('Reducer Reducer', () => {

--- a/client/src/app/store/selectors/app.selectors.spec.ts
+++ b/client/src/app/store/selectors/app.selectors.spec.ts
@@ -10,6 +10,7 @@ const stockInfo: Stock = {
   stockChange: -4.27,
   stockChangePercent: 1.68,
   stockValue: 16.36,
+  logo: ''
 };
 
 describe('Selectors', () => {


### PR DESCRIPTION
 
# Related Issue
- [111](https://github.com/DPigeon/Money-Tree/issues/111)

# Proposed changes
- Connected the backend endpoint to the frontend
- Display real stock data
# Additional Info
- To run and test this, the backend and database must be running
- When testing locally, you'll need this chrome extension turned on https://chrome.google.com/webstore/detail/moesif-origin-cors-change/digfbfaphojjndkpccljibejjbppifbc
- TODO: From the backend, enable CORS access to localhost. Discuss the way we handle data from the backend

# Checklist (if applicable)
- [X] Tests
- [X] Documentation

# Screenshots (if applicable)
![Screen Shot 2020-11-06 at 8 48 46 AM](https://user-images.githubusercontent.com/18631060/98373453-43daab80-200d-11eb-887e-17c56cbb6bd7.png)
![Screen Shot 2020-11-06 at 8 48 33 AM](https://user-images.githubusercontent.com/18631060/98373457-43daab80-200d-11eb-8374-87000dcffbb8.png)

# Reviewer(s)
 - @arthur-del 
 - @marwan011
 - @EspressoCode 
 - @DPigeon  
