### PR TITLE
Issue/#103: Investigate how to deploy Neo4J on Docker container

### DIFF
--- a/backend/docker-compose.yml
+++ b/backend/docker-compose.yml
@@ -1,0 +1,19 @@
+services:
+  money-tree-application:
+    build: .
+    restart: on-failure
+    ports:
+      - 8080:8080
+    links:
+      - neo4j
+    depends_on:
+      - neo4j
+  neo4j:
+    image: neo4j
+    restart: unless-stopped
+    ports:
+      - 7474:7474
+      - 7687:7687
+    volumes:
+      - /home/neo4j/data:/data
+      - /home/neo4j/logs:/logs


### PR DESCRIPTION
 
# Related Issue
- closes #103 

# Proposed changes
- Run neo4j in a container instead of separately

# Additional Info
- This is specific to deployment only. Instead of running using docker run, we will use docker-compose up.
- Action item:
- [ ] Change the deployment script in the vm to use docker-compose up

# Checklist (if applicable)
- [x] Tests N/A
- [x] Documentation N/A Documented in the issue

# Screenshots (if applicable)
N/A

| Before 🐛 | After 🦋 |
| --- | --- |
|  |  |

# Video or links (if applicable)
 - url

# Reviewer(s)
 - @DPigeon 
