### PR TITLE
issue/#149 backend coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,11 @@ jobs:
 
       - name: Backend Tests
         working-directory: ./backend
-        run: bash ./mvnw clean clover:setup test clover:aggregate clover:clover
+        run: bash ./mvnw clean test
 
       - name: Backend Package
         working-directory: ./backend
-        run: bash ./mvnw package
+        run: bash ./mvnw verify
 
       - name: Backend Run
         working-directory: ./backend
@@ -118,4 +118,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-        run: mvn -B verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+        run: mvn -B org.sonarsource.scanner.maven:sonar-maven-plugin:sonar

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,7 @@
 config.json
 
 client/test-report.xml
+
+# env files
+.env
+.envrc

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -161,11 +161,6 @@
                 <version>3.7.1</version>
             </plugin>
             <plugin>
-                <groupId>org.openclover</groupId>
-                <artifactId>clover-maven-plugin</artifactId>
-                <version>4.4.1</version>     
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>0.8.6</version>

--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -20,9 +20,10 @@
         <sonar.organization>money-tree</sonar.organization>
         <sonar.host.url>https://sonarcloud.io</sonar.host.url>
         <sonar.coverage.exclusions>
-            src/main/java/com/capstone/moneytree/model/**/*
+            src/main/java/com/capstone/moneytree/model/**/*,
             src/main/java/com/capstone/moneytree/utils/**/*
         </sonar.coverage.exclusions>
+        <sonar.coverage.jacoco.xmlReportPaths>target/site/jacoco/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
     </properties>
 
     <dependencies>
@@ -163,6 +164,31 @@
                 <groupId>org.openclover</groupId>
                 <artifactId>clover-maven-plugin</artifactId>
                 <version>4.4.1</version>     
+            </plugin>
+            <plugin>
+                <groupId>org.jacoco</groupId>
+                <artifactId>jacoco-maven-plugin</artifactId>
+                <version>0.8.6</version>
+                <configuration>
+                    <excludes>
+                        <exclude>com/capstone/moneytree/model/**/*</exclude>
+                        <exclude>com/capstone/moneytree/utils/**/*</exclude>
+                    </excludes>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>default-prepare-agent</id>
+                        <goals>
+                            <goal>prepare-agent</goal>
+                        </goals>
+                    </execution>
+                    <execution>
+                        <id>default-report</id>
+                        <goals>
+                            <goal>report</goal>
+                        </goals>
+                    </execution>
+                </executions>
             </plugin>
         </plugins>
     </build>


### PR DESCRIPTION
 
# Related Issue
- closes #149 

# Proposed changes
- Add jacoco coverage report

# Additional Info
- Sonarcloud coverage checks for a jacoco coverage report therefore we can't use the clover report for sonarcoud.
- Need to specify java file path starting from root for sonar exclusions.
- Need to specify class file path starting from target/class for jacoco exclusions.

- Changed the default branch on Sonarcloud to dev, as we want to compare new code with dev instead of master when we do pull requests.

# Reviewer(s)
 - @Alessandro100 @razine-bensari 
