### PR TITLE
Bug/signup password validation #197

### DIFF
--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -115,6 +115,7 @@ describe('SignupFormComponent', () => {
     component.pwd2.setValue('anotherPassword@@');
     component.pwd.markAsTouched();
     component.pwd2.markAsTouched();
+    component.pwd2.markAsDirty();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
       'Passwords do not match, please check.'

--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('SignupFormComponent', () => {
     component.pwd.markAsTouched();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
-      'Password must contain at least 8 characters, including one number, one letter and one of these special characters: @$!%*#?&'
+      'Password must contain at least 8 characters with no spaces, including one number, one letter and one of these special characters: @$!%*#?&'
     );
   });
 

--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('SignupFormComponent', () => {
     component.pwd.markAsTouched();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
-      'Password must contain at least 8 characters, including one number, one lowercase and one UPPERCASE letter, and no space.'
+      'Password must contain at least 8 characters, including one number, one lowercase and one uppercase letter, and no space.'
     );
   });
 

--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -39,8 +39,8 @@ describe('SignupFormComponent', () => {
     component.lastName.setValue('doe');
     component.username.setValue('johndoe');
     component.email.setValue('johndoe@gmail.com');
-    component.pwd.setValue('qwer@123');
-    component.pwd2.setValue('qwer@123');
+    component.pwd.setValue('Qwer@123');
+    component.pwd2.setValue('Qwer@123');
     fixture.detectChanges();
     component.onSubmit();
     const newUser: User = {
@@ -48,7 +48,7 @@ describe('SignupFormComponent', () => {
       lastName: 'doe',
       username: 'johndoe',
       email: 'johndoe@gmail.com',
-      password: 'qwer@123',
+      password: 'Qwer@123',
     };
     expect(component.userSignup.emit).toHaveBeenCalledWith(newUser);
     expect(component.showErrorMessage()).toBe(undefined);
@@ -98,7 +98,7 @@ describe('SignupFormComponent', () => {
     component.pwd.markAsTouched();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
-      'Password must contain at least 8 characters with no spaces, including one number, one letter and one of these special characters: @$!%*#?&'
+      'Password must contain at least 8 characters, including one number, one lowercase and one UPPERCASE letter, and no space.'
     );
   });
 
@@ -110,9 +110,9 @@ describe('SignupFormComponent', () => {
     );
   });
   it('should show an error if the passwords do not match', () => {
-    component.pwd.setValue('qwer@123');
+    component.pwd.setValue('Qwer@123');
     fixture.detectChanges();
-    component.pwd2.setValue('anotherPassword@@');
+    component.pwd2.setValue('AnotherPassword1@@');
     component.pwd.markAsTouched();
     component.pwd2.markAsTouched();
     component.pwd2.markAsDirty();

--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('SignupFormComponent', () => {
     component.pwd.markAsTouched();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
-      'Password must contain at least 8 characters, including one number, one lowercase and one uppercase letter, and no space.'
+      'Password must contain at least 8 characters, including one number, one symbol, one lowercase and one uppercase letter, and no space.'
     );
   });
 

--- a/client/src/app/components/signup-form/signup-form.component.spec.ts
+++ b/client/src/app/components/signup-form/signup-form.component.spec.ts
@@ -98,7 +98,7 @@ describe('SignupFormComponent', () => {
     component.pwd.markAsTouched();
     fixture.detectChanges();
     expect(component.showErrorMessage()).toBe(
-      'Password must be at least 8 characters, with one number, one letter and one symbol.'
+      'Password must contain at least 8 characters, including one number, one letter and one of these special characters: @$!%*#?&'
     );
   });
 

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -126,7 +126,7 @@ export class SignupFormComponent {
           return 'Email is not in the valid format.';
 
         case 'pwd,pattern':
-          return 'Password must be at least 8 characters, with one number, one letter and one symbol.';
+          return 'Password must contain at least 8 characters, including one number, one letter and one of these special characters: @$!%*#?&';
 
         case 'pwd2,pattern':
           return 'Passwords do not match, please check.';

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -131,7 +131,7 @@ export class SignupFormComponent {
           return 'Email is not in the valid format.';
 
         case 'pwd,pattern':
-          return 'Password must contain at least 8 characters, including one number, one letter and one of these special characters: @$!%*#?&';
+          return 'Password must contain at least 8 characters with no spaces, including one number, one letter and one of these special characters: @$!%*#?&';
 
         case 'pwds,match':
           return 'Passwords do not match, please check.';
@@ -139,7 +139,8 @@ export class SignupFormComponent {
     }
   }
 }
-function passwordMatch(frm: FormGroup): { [key: string]: boolean } { // custom validator
+function passwordMatch(frm: FormGroup): { [key: string]: boolean } {
+  // custom validator
   return frm.get('pwd').value === frm.get('pwd2').value
     ? null
     : { pwdsDidntMatch: true };

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -56,7 +56,7 @@ export class SignupFormComponent {
           Validators.compose([
             Validators.required,
             Validators.pattern(
-              /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/u
+              /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[\S]{8,}$/u
             ),
           ]),
         ],

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -1,3 +1,4 @@
+import { invalid } from '@angular/compiler/src/render3/view/util';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {
   FormBuilder,
@@ -6,6 +7,7 @@ import {
   AbstractControl,
 } from '@angular/forms';
 import { User } from 'src/app/interfaces/user';
+
 @Component({
   selector: 'app-signup-form',
   templateUrl: './signup-form.component.html',
@@ -23,40 +25,46 @@ export class SignupFormComponent {
   pwd2: AbstractControl;
 
   constructor(fb: FormBuilder) {
-    this.signUpForm = fb.group({
-      firstName: [
-        '',
-        Validators.compose([
-          Validators.required,
-          Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
-        ]),
-      ],
-      lastName: [
-        '',
-        Validators.compose([
-          Validators.required,
-          Validators.pattern(/^[a-zA-Z]{3,20}$/u),
-        ]),
-      ],
-      userName: [
-        '',
-        Validators.compose([
-          Validators.required,
-          Validators.pattern(/^[a-zA-Z]\w{5,20}$/u),
-        ]),
-      ],
-      email: ['', Validators.compose([Validators.required, Validators.email])],
-      pwd: [
-        '',
-        Validators.compose([
-          Validators.required,
-          Validators.pattern(
-            /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/u
-          ),
-        ]),
-      ],
-      pwd2: ['', Validators.compose([Validators.required])],
-    });
+    this.signUpForm = fb.group(
+      {
+        firstName: [
+          '',
+          Validators.compose([
+            Validators.required,
+            Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
+          ]),
+        ],
+        lastName: [
+          '',
+          Validators.compose([
+            Validators.required,
+            Validators.pattern(/^[a-zA-Z]{3,20}$/u),
+          ]),
+        ],
+        userName: [
+          '',
+          Validators.compose([
+            Validators.required,
+            Validators.pattern(/^[a-zA-Z]\w{5,20}$/u),
+          ]),
+        ],
+        email: [
+          '',
+          Validators.compose([Validators.required, Validators.email]),
+        ],
+        pwd: [
+          '',
+          Validators.compose([
+            Validators.required,
+            Validators.pattern(
+              /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[A-Za-z\d@$!%*#?&]{8,}$/u
+            ),
+          ]),
+        ],
+        pwd2: ['', Validators.compose([Validators.required])],
+      },
+      { validator: passwordMatch } // This would be a custom validator to check whether passwords matched.
+    );
 
     this.firstName = this.signUpForm.controls.firstName;
     this.lastName = this.signUpForm.controls.lastName;
@@ -80,10 +88,8 @@ export class SignupFormComponent {
   }
 
   getFirstErrorMessage(): string {
-    // creating pattern (pwd match) validator for confirm password field only if password is already have a value and not null
-    if (this.pwd.value) {
-      const regex = new RegExp('^' + this.pwd.value + '$');
-      this.pwd2.setValidators([Validators.required, Validators.pattern(regex)]);
+    if (this.signUpForm.hasError('pwdsDidntMatch') && this.pwd2.dirty) {
+      return 'pwds,match';
     }
     // Only 1 error msg is shown at a time, the first input field error is prior to second, and same for next ones
     if (this.signUpForm.touched && this.signUpForm.invalid) {
@@ -128,9 +134,14 @@ export class SignupFormComponent {
         case 'pwd,pattern':
           return 'Password must contain at least 8 characters, including one number, one letter and one of these special characters: @$!%*#?&';
 
-        case 'pwd2,pattern':
+        case 'pwds,match':
           return 'Passwords do not match, please check.';
       }
     }
   }
+}
+function passwordMatch(frm: FormGroup): { [key: string]: boolean } { // custom validator
+  return frm.get('pwd').value === frm.get('pwd2').value
+    ? null
+    : { pwdsDidntMatch: true };
 }

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -55,7 +55,9 @@ export class SignupFormComponent {
           '',
           Validators.compose([
             Validators.required,
-            Validators.pattern(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[\S]{8,}$/u),
+            Validators.pattern(
+              /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\d\s])[\S]{8,}$/u
+            ),
           ]),
         ],
         pwd2: ['', Validators.compose([Validators.required])],
@@ -133,7 +135,7 @@ export class SignupFormComponent {
           return 'Email is not in the valid format.';
 
         case 'pwd,pattern':
-          return 'Password must contain at least 8 characters, including one number, one lowercase and one uppercase letter, and no space.';
+          return 'Password must contain at least 8 characters, including one number, one symbol, one lowercase and one uppercase letter, and no space.';
 
         case 'pwds,match':
           return 'Passwords do not match, please check.';

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -1,4 +1,3 @@
-import { invalid } from '@angular/compiler/src/render3/view/util';
 import { Component, EventEmitter, Input, Output } from '@angular/core';
 import {
   FormBuilder,

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -55,9 +55,7 @@ export class SignupFormComponent {
           '',
           Validators.compose([
             Validators.required,
-            Validators.pattern(
-              /^(?=.*[A-Za-z])(?=.*\d)(?=.*[@$!%*#?&])[\S]{8,}$/u
-            ),
+            Validators.pattern(/^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)[\S]{8,}$/u),
           ]),
         ],
         pwd2: ['', Validators.compose([Validators.required])],
@@ -131,7 +129,7 @@ export class SignupFormComponent {
           return 'Email is not in the valid format.';
 
         case 'pwd,pattern':
-          return 'Password must contain at least 8 characters with no spaces, including one number, one letter and one of these special characters: @$!%*#?&';
+          return 'Password must contain at least 8 characters, including one number, one lowercase and one UPPERCASE letter, and no space.';
 
         case 'pwds,match':
           return 'Passwords do not match, please check.';

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -85,7 +85,11 @@ export class SignupFormComponent {
   }
 
   getFirstErrorMessage(): string {
-    if (this.signUpForm.hasError('pwdsDidntMatch') && this.pwd2.dirty) {
+    if (
+      this.signUpForm.hasError('pwdsDidntMatch') &&
+      this.pwd2.dirty &&
+      this.pwd.valid
+    ) {
       return 'pwds,match';
     }
     // Only 1 error msg is shown at a time, the first input field error is prior to second, and same for next ones
@@ -129,7 +133,7 @@ export class SignupFormComponent {
           return 'Email is not in the valid format.';
 
         case 'pwd,pattern':
-          return 'Password must contain at least 8 characters, including one number, one lowercase and one UPPERCASE letter, and no space.';
+          return 'Password must contain at least 8 characters, including one number, one lowercase and one uppercase letter, and no space.';
 
         case 'pwds,match':
           return 'Passwords do not match, please check.';


### PR DESCRIPTION
 
# Related Issue
- This pr is a bug fix for:  #197  

# Proposed changes
- Change the error message for prompting user to have at list one symbol in password, now by showing a given list of symbols.
- Password match should work fine now by adding a custom validator to the form (instead of dynamically setting the validator).

# Reviewer(s)
 - @Alessandro100 @wltrf  @DPigeon 
