### PR TITLE
fixed styling for autocomplete/autofill #196

### DIFF
--- a/client/src/forms.scss
+++ b/client/src/forms.scss
@@ -14,6 +14,14 @@
   position: absolute;
 }
 
+input:-webkit-autofill,
+input:-webkit-autofill:hover,
+input:-webkit-autofill:focus,
+input:-webkit-autofill:active {
+  transition: background-color 5000s;
+  -webkit-text-fill-color: $mt-dark !important;
+}
+
 @media only screen and (max-width: 600px) {
   .form-error-messages {
     font-size: 16px;


### PR DESCRIPTION
 
# Related Issue
- #196 Blue Rectangle Appears on Recent Text Form

# Proposed changes
- This pr will overwrite and fix the styling for when the input is filled out by autofill/autocomplete from the browser.

# Additional Info
- I tested it on Chrome ver. 87.0.4280.88 and Edge ver. 87.0.664.57 on Windows, please try it on other browsers. If the issue cannot be resolved by these changes, we might disable autofill for forms as an alternative, which I do not really like that.

# Reviewer(s)
 - @DPigeon @Alessandro100 
