### PR TITLE
Issue/#176 default user value

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
@@ -104,8 +104,8 @@ public class UserController {
       return userService.login(credentials);
    }
 
-   @PutMapping("/{id}")
-   ResponseEntity<User> editUserProfile(@PathVariable Long id,
+   @PutMapping("/profile-picture/{id}")
+   ResponseEntity<User> editUserProfilePicture(@PathVariable Long id,
                                         @RequestParam(required = false) MultipartFile imageFile) {
       User userToUpdate = this.userService.getUserById(id);
       if (imageFile == null || imageFile.isEmpty()) {

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -29,6 +29,7 @@ import com.capstone.moneytree.validator.ValidatorFactory;
 public class DefaultUserService implements UserService {
 
    private static final String USER_NOT_FOUND = "The requested user was not found";
+   private static final String DEFAULT_PROFILE_NAME = "DEFAULT-profile.jpg";
 
    private final UserDao userDao;
    private final ValidatorFactory validatorFactory;
@@ -37,9 +38,6 @@ public class DefaultUserService implements UserService {
    private final AmazonS3Service amazonS3Service;
 
    private final String bucketName;
-
-   @Value("${aws.default.profile.picture}")
-   private String defaultProfileURL;
 
    @Autowired
    public DefaultUserService(UserDao userDao, ValidatorFactory validatorFactory, AmazonS3Service amazonS3Service, @Value("${aws.profile.pictures.bucket}") String bucketName) {
@@ -81,7 +79,7 @@ public class DefaultUserService implements UserService {
       String password = user.getPassword();
       String encryptedPassword = encryptData(password);
       user.setPassword(encryptedPassword);
-      user.setAvatarURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, defaultProfileURL));
+      user.setAvatarURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, DEFAULT_PROFILE_NAME));
 
       userDao.save(user);
 
@@ -96,7 +94,8 @@ public class DefaultUserService implements UserService {
       String imageUrl = amazonS3Service.uploadImageToS3Bucket(imageFile, getBucketName());
 
       //if user already has a profile picture that is not the default picture, handle deleting old picture
-      if (StringUtils.isNotBlank(user.getAvatarURL()) && !user.getAvatarURL().contains(defaultProfileURL)) {
+      if (StringUtils.isNotBlank(user.getAvatarURL()) && !user.getAvatarURL().contains(DEFAULT_PROFILE_NAME)) {
+         String test = "fgh";
          this.amazonS3Service.deleteImageFromS3Bucket(getBucketName(), user.getAvatarURL());
       }
 

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -95,7 +95,6 @@ public class DefaultUserService implements UserService {
 
       //if user already has a profile picture that is not the default picture, handle deleting old picture
       if (StringUtils.isNotBlank(user.getAvatarURL()) && !user.getAvatarURL().contains(DEFAULT_PROFILE_NAME)) {
-         String test = "fgh";
          this.amazonS3Service.deleteImageFromS3Bucket(getBucketName(), user.getAvatarURL());
       }
 

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -37,16 +37,17 @@ public class DefaultUserService implements UserService {
    private final AmazonS3Service amazonS3Service;
 
    private final String bucketName;
-   private final String defaultProfileURL;
+
+   @Value("${aws.default.profile.picture}")
+   private String defaultProfileURL;
 
    @Autowired
-   public DefaultUserService(UserDao userDao, ValidatorFactory validatorFactory, AmazonS3Service amazonS3Service, @Value("${aws.profile.pictures.bucket}") String bucketName, @Value("${aws.default.profile.picture}") String defaultProfileURL) {
+   public DefaultUserService(UserDao userDao, ValidatorFactory validatorFactory, AmazonS3Service amazonS3Service, @Value("${aws.profile.pictures.bucket}") String bucketName) {
       this.userDao = userDao;
       this.validatorFactory = validatorFactory;
       this.passwordEncryption = new MoneyTreePasswordEncryption();
       this.amazonS3Service = amazonS3Service;
       this.bucketName = bucketName;
-      this.defaultProfileURL = defaultProfileURL;
    }
 
    @Override

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -26,4 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}
+aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -26,3 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
+aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}

--- a/backend/src/main/resources/application-local.properties
+++ b/backend/src/main/resources/application-local.properties
@@ -26,4 +26,3 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -26,4 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_PROD}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}
+aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -26,3 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_PROD}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
+aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -26,4 +26,3 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_PROD}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,4 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}
+aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,3 +26,4 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
+aws.default.profile.picture=${DEFAULT_PROFILE_PICTURE}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -26,4 +26,3 @@ IEXCloud.secret.token=${IEXCLOUD_SECRET_TOKEN_SANDBOX}
 aws.access.key.id=${AWS_ACCESS_KEY}
 aws.secret.access.key=${AWS_SECRET_ACCESS_KEY}
 aws.profile.pictures.bucket=${AWS_PROFILE_PICTURES_BUCKET}
-aws.default.profile.picture=DEFAULT-profile.jpg

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
@@ -247,7 +247,7 @@ class UserControllerTest extends Specification {
    }
 
    @Test
-   def "Edit User is returns an exception if the provided image is empty"() {
+   def "Edit User Profile Picture returns an exception if the provided image is empty"() {
       given: "A registered user with an Alpaca key"
       String email = "moneytree@test.com"
       String username = "Billy"
@@ -265,14 +265,14 @@ class UserControllerTest extends Specification {
       imageFile.isEmpty() >> true
 
       when: "Attempt to editUserProfile without a png file"
-      userController.editUserProfile(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile)
 
       then:
       thrown(InvalidMediaFileException)
    }
 
    @Test
-   def "Edit User is returns an exception if the provided image is null"() {
+   def "Edit User Profile Picture is returns an exception if the provided image is null"() {
       given: "A registered user with an Alpaca key"
       String email = "moneytree@test.com"
       String username = "Billy"
@@ -289,14 +289,14 @@ class UserControllerTest extends Specification {
       MultipartFile imageFile = null
 
       when: "Attempt to editUserProfile without a png file"
-      userController.editUserProfile(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile)
 
       then:
       thrown(InvalidMediaFileException)
    }
 
    @Test
-   def "Edit User is successful if the user uploads its first picture ever"() {
+   def "Edit User Profile Picture is successful if the user uploads its first picture ever"() {
       given: "A registered user"
       def user = new User(
               id: 123,
@@ -311,7 +311,7 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile"
-      def response = userController.editUserProfile(user.getId(), getMultipartFile())
+      def response = userController.editUserProfilePicture(user.getId(), getMultipartFile())
 
       then: "The returned avatar url contains the profile picture name uploaded by the user"
       with(response) {
@@ -325,7 +325,7 @@ class UserControllerTest extends Specification {
    }
 
    @Test
-   def "Edit User successfully deletes the previous avatar when present"() {
+   def "Edit User Profile Picture successfully deletes the previous avatar when present"() {
       given: "A registered user"
       def user = new User(
               id: 123,
@@ -346,7 +346,7 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile"
-      def response = userController.editUserProfile(user.getId(), image)
+      def response = userController.editUserProfilePicture(user.getId(), image)
 
       then: "The returned avatar url contains the profile picture name uploaded by the user"
       with(response) {
@@ -360,7 +360,7 @@ class UserControllerTest extends Specification {
    }
 
    @Test
-   def "Edit User throws exception when image is null"() {
+   def "Edit User Profile Picture throws exception when image is null"() {
       given: "A registered user"
       def user = new User(
               id: 123,
@@ -375,14 +375,14 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile when image is null"
-      userController.editUserProfile(user.getId(), null)
+      userController.editUserProfilePicture(user.getId(), null)
 
       then: "throws an invalidMediaException"
       thrown(InvalidMediaFileException)
    }
 
    @Test
-   def "Edit User throws exception when image is empty"() {
+   def "Edit User Profile Picture throws exception when image is empty"() {
       given: "A registered user"
       def user = new User(
               id: 123,
@@ -402,7 +402,7 @@ class UserControllerTest extends Specification {
       }
 
       when: "Attempt to editUserProfile when image is empty but not null"
-      userController.editUserProfile(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile)
 
       then: "throws an invalidMediaException"
       thrown(InvalidMediaFileException)


### PR DESCRIPTION
 
# Related Issue
- [link to the issue on zenhub](https://app.zenhub.com/workspaces/moneytree-board-5f5bcf1c7ea48f001c28c973/issues/dpigeon/money-tree/176)

# Proposed changes
- newly created user will have a predefined avatarURL pointing to a default image stored in s3
- when the user updates his default image, the default image is NOT deleted from s3
- endpoint exclusively used for updating image, change to => PUT /users/profile-picture/{id}

# Reviewer(s)
 - @razine-bensari @DPigeon @Alessandro100 
