### PR TITLE
#198 changed BE to check for username or email

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/dao/UserDao.java
+++ b/backend/src/main/java/com/capstone/moneytree/dao/UserDao.java
@@ -19,4 +19,6 @@ public interface UserDao extends Neo4jRepository<User, Long> {
     User findUserByEmailAndUsername(String email, String username);
 
     User findUserByEmail(String email);
+
+    User findUserByUsername(String username);
 }

--- a/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
+++ b/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
@@ -45,11 +45,9 @@ public class UserValidator implements Validator {
    }
 
    public void validateEmptyFields(User user) {
-      if (StringUtils.isBlank(user.getPassword()) ||
-              StringUtils.isBlank(user.getUsername()) ||
-              StringUtils.isBlank(user.getEmail()) ||
-              StringUtils.isBlank(user.getFirstName()) ||
-              StringUtils.isBlank(user.getLastName())) {
+      if (StringUtils.isBlank(user.getPassword()) || StringUtils.isBlank(user.getUsername())
+            || StringUtils.isBlank(user.getEmail()) || StringUtils.isBlank(user.getFirstName())
+            || StringUtils.isBlank(user.getLastName())) {
          throw new MissingMandatoryFieldException(String.format("Missing field for %s", User.class));
       }
    }
@@ -61,8 +59,7 @@ public class UserValidator implements Validator {
     * @return boolean if exists or not.
     */
    private boolean userAlreadyExists(User user) {
-      return Objects.nonNull(getUserDao().
-              findUserByEmailAndUsername(user.getEmail(), user.getUsername()));
+      return Objects.nonNull(getUserDao().findUserByEmail(user.getEmail())) ||  Objects.nonNull(getUserDao().findUserByUsername(user.getUsername()));
    }
 
    public UserDao getUserDao() {

--- a/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
+++ b/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
@@ -37,8 +37,12 @@ public class UserValidator implements Validator {
    }
 
    public void validateEmailAndUsername(User user) {
-      if (userAlreadyExists(user)) {
-         String errorMessage = "The email address or username already exist";
+      if (emailAlreadyExists(user)) {
+         String errorMessage = "The email address already exist!";
+         LOG.error(errorMessage);
+         throw new UserAlreadyExistsException(errorMessage);
+      } else if (usernameAlreadyExists(user)) {
+         String errorMessage = "The username already exist!";
          LOG.error(errorMessage);
          throw new UserAlreadyExistsException(errorMessage);
       }
@@ -53,14 +57,23 @@ public class UserValidator implements Validator {
    }
 
    /**
-    * Method to look if user exists with unique email and username.
+    * Method to look if user exists with unique email address.
     *
     * @param user User from front end.
     * @return boolean if exists or not.
     */
-   private boolean userAlreadyExists(User user) {
-      return Objects.nonNull(getUserDao().findUserByEmail(user.getEmail()))
-       ||    Objects.nonNull(getUserDao().findUserByUsername(user.getUsername()));
+   private boolean emailAlreadyExists(User user) {
+      return Objects.nonNull(getUserDao().findUserByEmail(user.getEmail()));
+   }
+
+   /**
+    * Method to look if user exists with unique username.
+    *
+    * @param user User from front end.
+    * @return boolean if exists or not.
+    */
+   private boolean usernameAlreadyExists(User user) {
+      return Objects.nonNull(getUserDao().findUserByUsername(user.getUsername()));
    }
 
    public UserDao getUserDao() {

--- a/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
+++ b/backend/src/main/java/com/capstone/moneytree/validator/UserValidator.java
@@ -59,7 +59,8 @@ public class UserValidator implements Validator {
     * @return boolean if exists or not.
     */
    private boolean userAlreadyExists(User user) {
-      return Objects.nonNull(getUserDao().findUserByEmail(user.getEmail())) ||  Objects.nonNull(getUserDao().findUserByUsername(user.getUsername()));
+      return Objects.nonNull(getUserDao().findUserByEmail(user.getEmail()))
+       ||    Objects.nonNull(getUserDao().findUserByUsername(user.getUsername()));
    }
 
    public UserDao getUserDao() {

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
@@ -113,7 +113,7 @@ class UserControllerTest extends Specification {
       User user = createUser(email, username, password, firstName, lastName, null)
 
       and: "mock the database with some users already registered"
-      userDao.findUserByEmailAndUsername(user.getEmail(), user.getUsername()) >> user
+      userDao.findUserByEmail(user.getEmail()) >> user
 
       when: "creating a user"
       userController.createUser(user)
@@ -133,7 +133,7 @@ class UserControllerTest extends Specification {
       User user = createUser(email, username, password, firstName, lastName, null)
 
       and: "mock the database with some users already registered"
-      userDao.findUserByEmailAndUsername(user.getEmail(), user.getUsername()) >> user
+      userDao.findUserByUsername(user.getUsername()) >> user
 
       when: "creating a user"
       userController.createUser(user)

--- a/backend/src/test/groovy/com/capstone/moneytree/validator/UserValidatorTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/validator/UserValidatorTest.groovy
@@ -83,17 +83,36 @@ class UserValidatorTest extends Specification {
       "test@test.com" | "Test"   | "encrypted" | "John"    | null     | MissingMandatoryFieldException
    }
 
-   def "validation throws UserAlreadyExistsException for the email and username field"() {
-      given: "A user that already exist"
+   def "validation throws UserAlreadyExistsException for the email field"() {
+      given: "An email that already exist"
       String email = "test@test.com"
+      String username = "Test_2"
+      String password = "encrypted"
+      String firstName = "John"
+      String lastName = "Doe"
+      user = createUser(email, username, password, firstName, lastName, "")
+
+      and: "userDao finds that user by email in db"
+      userDao.findUserByEmail(user.getEmail()) >> user
+
+      when: "We validate a user"
+      userValidator.validate(user)
+
+      then:
+      thrown(UserAlreadyExistsException)
+   }
+
+   def "validation throws UserAlreadyExistsException for the username field"() {
+      given: "A username that already exist"
+      String email = "test_2@test.com"
       String username = "Test"
       String password = "encrypted"
       String firstName = "John"
       String lastName = "Doe"
       user = createUser(email, username, password, firstName, lastName, "")
 
-      and: "userDao returns null (no user such user in db)"
-      userDao.findUserByEmailAndUsername(user.getEmail(), user.getUsername()) >> user
+      and: "userDao finds that user by username in db"
+      userDao.findUserByUsername(user.getUsername()) >> user
 
       when: "We validate a user"
       userValidator.validate(user)

--- a/client/src/app/components/signup-form/signup-form.component.html
+++ b/client/src/app/components/signup-form/signup-form.component.html
@@ -31,8 +31,7 @@
             [disabled]="disableButton()">
             SIGN UP
         </button>
-        <div class="form-error-messages" *ngIf="userAlreadyExist()">A user with this email address or username already
-            exist!
+        <div class="form-error-messages" *ngIf="userAlreadyExist()">{{appError.debugMessage}}
         </div>
         <div class="form-error-messages" *ngIf="signUpForm.invalid && !userAlreadyExist()">
             {{ showErrorMessage() }}


### PR DESCRIPTION
# Related Issue
- This PR is a bug fix for #198 Unique-Email-Username-Validation 
# Proposed changes
- Changed the userAlreadyExists method to check for username or email separately.
- Now when the user tries to put a username or email that is already in database (for signUp), an error will be shown which specifies which one must be fixed.

# Reviewer(s)
@DPigeon  @razine-bensari  @Alessandro100 
