### PR TITLE
Remove expensive calls from batch in facade

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/facade/StockMarketDataFacade.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/StockMarketDataFacade.java
@@ -60,10 +60,8 @@ public class StockMarketDataFacade {
                 .withSymbol(symbol)
                 .addType(BatchStocksType.BOOK)
                 .addType(BatchStocksType.COMPANY)
-                .addType(BatchStocksType.NEWS).withLast(10)
                 .addType(BatchStocksType.KEY_STATS)
                 .addType(BatchStocksType.LOGO)
-                .addType(BatchStocksType.CHART)
                 .build()
         );
     }


### PR DESCRIPTION
 
# Related Issue
- #179 

# Proposed changes
- Remove expensive calls for /batch in the facade (NEWS weight 10 and CHART/HISTORICAL PRICES weight 100)

# Additional Info
- This reduces the /batch/{symbol} call cost from 118 to 8, which is a good improvement.
- Further solution would be to have every user provide their own api key just like with alpaca (we could create it on their behalf)

# Reviewer(s)
 - @razine-bensari 
 - @abdulmansour 
 - @DPigeon
