### PR TITLE
Feature/#182 create edit profile page form logic

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
@@ -26,7 +26,6 @@ import com.capstone.moneytree.handler.ExceptionMessage;
 import com.capstone.moneytree.model.node.User;
 import com.capstone.moneytree.service.api.UserService;
 
-
 @MoneyTreeController
 @RequestMapping("/users")
 public class UserController {
@@ -69,7 +68,8 @@ public class UserController {
    }
 
    /**
-    * A method that updates a user with a new Alpaca key. This should be done only once at beginning
+    * A method that updates a user with a new Alpaca key. This should be done only
+    * once at beginning
     *
     * @param id  The user ID sent from the frontend
     * @param key The Alpaca API key sent from the frontend
@@ -95,12 +95,11 @@ public class UserController {
     * /login POST endpoint to authenticate a user
     *
     * @param credentials A User object with email and unencrypted password
-    * @return The full User object from the database if login is successful with 200 OK, 404 NOT_FOUND otherwise
+    * @return The full User object from the database if login is successful with
+    *         200 OK, 404 NOT_FOUND otherwise
     */
    @PostMapping("/login")
-   public User login(@RequestBody User credentials)
-           throws
-           CredentialNotFoundException {
+   public User login(@RequestBody User credentials) throws CredentialNotFoundException {
       return userService.login(credentials);
    }
 
@@ -113,12 +112,12 @@ public class UserController {
 
    @PostMapping("/profile-picture/{id}")
    ResponseEntity<User> editUserProfilePicture(@PathVariable Long id,
-                                               @RequestParam(required = false) MultipartFile imageFile) {
+         @RequestParam(required = false) MultipartFile imageFile, @RequestParam String selection) {
       User userToUpdate = this.userService.getUserById(id);
       if (imageFile == null || imageFile.isEmpty()) {
          throw new InvalidMediaFileException("The provided profile picture is null or empty");
       }
-      return ResponseEntity.ok(this.userService.editUserProfilePicture(userToUpdate, imageFile));
+      return ResponseEntity.ok(this.userService.editUserProfilePicture(userToUpdate, imageFile, selection));
    }
 
    @DeleteMapping("/delete-by-email/{email}")

--- a/backend/src/main/java/com/capstone/moneytree/model/node/User.java
+++ b/backend/src/main/java/com/capstone/moneytree/model/node/User.java
@@ -35,6 +35,8 @@ public class User extends Entity {
 
     String alpacaApiKey;
 
+    String biography;
+
     @Relationship(type = "FOLLOWS", direction = Relationship.INCOMING)
     Set<User> followers;
 

--- a/backend/src/main/java/com/capstone/moneytree/model/node/User.java
+++ b/backend/src/main/java/com/capstone/moneytree/model/node/User.java
@@ -23,6 +23,8 @@ public class User extends Entity {
 
     String avatarURL;
 
+    String coverPhotoURL;
+    
     String email;
 
     Double score;

--- a/backend/src/main/java/com/capstone/moneytree/service/api/UserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/api/UserService.java
@@ -40,7 +40,7 @@ public interface UserService {
 
    User login(User credentials) throws CredentialNotFoundException;
 
-   User editUserProfilePicture(User user, MultipartFile imageFile);
+   User editUserProfilePicture(User user, MultipartFile imageFile, String selection);
 
    void deleteUserByEmail(String email);
 

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -81,6 +81,7 @@ public class DefaultUserService implements UserService {
       String encryptedPassword = encryptData(password);
       user.setPassword(encryptedPassword);
       user.setAvatarURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, DEFAULT_PROFILE_NAME));
+      user.setCoverPhotoURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, DEFAULT_PROFILE_NAME)); // TODO: must be changed to a general cover photo
 
       userDao.save(user);
 
@@ -119,6 +120,11 @@ public class DefaultUserService implements UserService {
       if (user.getAvatarURL() != null) {
          userToUpdate.setAvatarURL(user.getAvatarURL());
       }
+
+      if (user.getCoverPhotoURL() != null) {
+         userToUpdate.setCoverPhotoURL(user.getCoverPhotoURL());
+      }
+
       if (user.getBiography() != null) {
          userToUpdate.setBiography(user.getBiography());
       }
@@ -162,21 +168,39 @@ public class DefaultUserService implements UserService {
    }
 
    @Override
-   public User editUserProfilePicture(User user, MultipartFile imageFile) {
-      // since user exists, we can now upload image to s3 and save imageUrl into db
-      String imageUrl = amazonS3Service.uploadImageToS3Bucket(imageFile, getBucketName());
+   public User editUserProfilePicture(User user, MultipartFile imageFile, String selection) {
 
-      // if user already has a profile picture that is not the default picture, handle
-      // deleting old picture
-      if (StringUtils.isNotBlank(user.getAvatarURL()) && !user.getAvatarURL().contains(DEFAULT_PROFILE_NAME)) {
-         this.amazonS3Service.deleteImageFromS3Bucket(getBucketName(), user.getAvatarURL());
+      switch (selection) {
+         case "avatarURL": {
+            // since user exists, we can now upload image to s3 and save imageUrl into db
+            String imageUrl = amazonS3Service.uploadImageToS3Bucket(imageFile, getBucketName());
+            // if user already has a profile picture that is not the default picture, handle
+            // deleting old picture
+            if (StringUtils.isNotBlank(user.getAvatarURL()) && !user.getAvatarURL().contains(DEFAULT_PROFILE_NAME)) {
+               this.amazonS3Service.deleteImageFromS3Bucket(getBucketName(), user.getAvatarURL());
+            }
+            // set new image url
+            user.setAvatarURL(imageUrl);
+            userDao.save(user);
+            LOG.info("Edited {}'s profile picture successfully!", user.getUsername());
+            break;
+         }
+         case "coverPhotoURL": {
+            String imageUrl = amazonS3Service.uploadImageToS3Bucket(imageFile, getBucketName());
+            if (StringUtils.isNotBlank(user.getCoverPhotoURL())
+                  && !user.getCoverPhotoURL().contains(DEFAULT_PROFILE_NAME)) {
+               this.amazonS3Service.deleteImageFromS3Bucket(getBucketName(), user.getCoverPhotoURL());
+            }
+            // set new image url
+            user.setCoverPhotoURL(imageUrl);
+            userDao.save(user);
+            LOG.info("Edited {}'s profile cover photo successfully!", user.getUsername());
+            break;
+         }
+         default:
+            LOG.info("Photo was not saved on Amazon S3!");
+            throw new BadRequestException(String.format("Wrong selection string was put as parameter."));
       }
-
-      // set new image url
-      user.setAvatarURL(imageUrl);
-      userDao.save(user);
-
-      LOG.info("Edited {}'s profile successfully!", user.getUsername());
       return user;
    }
 

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerTest.groovy
@@ -267,7 +267,7 @@ class UserControllerTest extends Specification {
       imageFile.isEmpty() >> true
 
       when: "Attempt to editUserProfile without a png file"
-      userController.editUserProfilePicture(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile, "avatarURL")
 
       then:
       thrown(InvalidMediaFileException)
@@ -291,7 +291,7 @@ class UserControllerTest extends Specification {
       MultipartFile imageFile = null
 
       when: "Attempt to editUserProfile without a png file"
-      userController.editUserProfilePicture(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile, "avatarURL")
 
       then:
       thrown(InvalidMediaFileException)
@@ -313,7 +313,7 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile"
-      def response = userController.editUserProfilePicture(user.getId(), getMultipartFile())
+      def response = userController.editUserProfilePicture(user.getId(), getMultipartFile(), "avatarURL")
 
       then: "The returned avatar url contains the profile picture name uploaded by the user"
       with(response) {
@@ -348,7 +348,7 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile"
-      def response = userController.editUserProfilePicture(user.getId(), image)
+      def response = userController.editUserProfilePicture(user.getId(), image, "avatarURL")
 
       then: "The returned avatar url contains the profile picture name uploaded by the user"
       with(response) {
@@ -377,7 +377,7 @@ class UserControllerTest extends Specification {
       userDao.findUserById(user.getId()) >> user
 
       when: "Attempt to editUserProfile when image is null"
-      userController.editUserProfilePicture(user.getId(), null)
+      userController.editUserProfilePicture(user.getId(), null, "avatarURL")
 
       then: "throws an invalidMediaException"
       thrown(InvalidMediaFileException)
@@ -404,7 +404,7 @@ class UserControllerTest extends Specification {
       }
 
       when: "Attempt to editUserProfile when image is empty but not null"
-      userController.editUserProfilePicture(user.getId(), imageFile)
+      userController.editUserProfilePicture(user.getId(), imageFile, "avatarURL")
 
       then: "throws an invalidMediaException"
       thrown(InvalidMediaFileException)

--- a/client/e2e/src/user-auth.po.ts
+++ b/client/e2e/src/user-auth.po.ts
@@ -7,7 +7,7 @@ const systemTestUser2 = {
   firstName: 'System',
   lastName: 'Test',
   username: 'SystemTestUser',
-  avatarUrl: '',
+  avatarURL: '',
   password: 'Hunter42',
   email: 'systemtestuser1@systemtestuser.com',
   score: 12,

--- a/client/e2e/src/user-auth.po.ts
+++ b/client/e2e/src/user-auth.po.ts
@@ -8,6 +8,7 @@ const systemTestUser2 = {
   lastName: 'Test',
   username: 'SystemTestUser',
   avatarURL: '',
+  coverPhotoURL: '',
   password: 'Hunter42',
   email: 'systemtestuser1@systemtestuser.com',
   score: 12,

--- a/client/sonar-project.properties
+++ b/client/sonar-project.properties
@@ -6,4 +6,4 @@ sonar.projectName=money-tree_FRONTEND
 #sonar.projectVersion=1.0
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
-sonar.cpd.exclusions=./client/src/app/components/edit-profile/edit-profile.component.spec.ts
+sonar.cpd.exclusions=**/*spec.ts

--- a/client/sonar-project.properties
+++ b/client/sonar-project.properties
@@ -6,3 +6,4 @@ sonar.projectName=money-tree_FRONTEND
 #sonar.projectVersion=1.0
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info
+sonar.cpd.exclusions=./client/src/app/components/edit-profile/edit-profile.component.spec.ts

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -9,74 +9,49 @@
     </button>
 
     <div class="profile-picture">
-      <img
-        src="https://ollienollie.files.wordpress.com/2009/10/untitled-181.jpg"
-        alt="profile picture"
-        class="profile-pic"
-      />
+      <img src="https://ollienollie.files.wordpress.com/2009/10/untitled-181.jpg" alt="profile picture"
+        class="profile-pic" />
       <button mat-icon-button class="edit-profile-pic">
         <mat-icon>add_a_photo</mat-icon>
       </button>
     </div>
   </div>
 
-  <form class="edit-profile-form">
-    <mat-form-field
-      class="mt-input-field half"
-      appearance="outline"
-      color="coral"
-    >
+  <div class="form-error-messages" *ngIf="editProfileForm.invalid">
+    {{ showErrorMessage() }}
+  </div>
+
+  <form [formGroup]="editProfileForm" class="edit-profile-form">
+
+    <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
       <mat-label>First Name</mat-label>
-      <input matInput placeholder="First Name" />
+      <input matInput placeholder="First Name" [formControl]="firstName" />
     </mat-form-field>
 
-    <mat-form-field
-      class="mt-input-field half"
-      appearance="outline"
-      color="coral"
-    >
+    <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
       <mat-label>Last Name</mat-label>
-      <input matInput placeholder="Last Name" />
+      <input matInput placeholder="Last Name" [formControl]="lastName" />
     </mat-form-field>
 
-    <mat-form-field
-      class="mt-input-field textarea bio"
-      appearance="outline"
-      color="coral"
-    >
+    <mat-form-field class="mt-input-field textarea bio" appearance="outline" color="coral">
       <mat-label>Bio</mat-label>
-      <textarea
-        matInput
-        placeholder="Bio"
-        matTextareaAutosize
-        matAutosizeMinRows="5"
-        matAutosizeMaxRows="10"
-      ></textarea>
+      <textarea matInput placeholder="Bio" matTextareaAutosize matAutosizeMinRows="5" matAutosizeMaxRows="10"
+        [formControl]="bio"></textarea>
     </mat-form-field>
 
-    <mat-form-field
-      class="mt-input-field half"
-      appearance="outline"
-      color="coral"
-    >
+    <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
       <mat-label>New Password</mat-label>
-      <input matInput placeholder="New password" type="password" />
+      <input matInput placeholder="New password" type="password" [formControl]="newPwd" />
     </mat-form-field>
 
-    <mat-form-field
-      class="mt-input-field half"
-      appearance="outline"
-      color="coral"
-    >
+    <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
       <mat-label>Confirm New Password</mat-label>
-      <input matInput placeholder="Confirm New Password" type="password" />
+      <input matInput placeholder="Confirm New Password" type="password" [formControl]="newPwd2" />
     </mat-form-field>
 
-    <button
-      class="mt-input-field secondary-action-btn"
-      mat-flat-button
-      type="submit"
-    >
+    <button class="mt-input-field secondary-action-btn" mat-flat-button type="submit"
+      [class.btn-opacity-disabled]="editProfileForm.invalid"
+      [disabled]="!editProfileForm.valid || !editProfileForm.touched">
       Save Changes
     </button>
   </form>

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -1,28 +1,39 @@
 <div class="container">
-  <div class="cover-picture">
+
+  <div class="photos-container">
     <button mat-icon-button class="close-dialog-icon" mat-dialog-close>
       <mat-icon>close</mat-icon>
     </button>
-    <button mat-button class="edit-cover-picture">
-      <input single type="file" id="cover-photo" style="display: none;" />
+
+    <img [src]="userCoverPhotoURL" alt="cover photo picture" class="cover-pic-img" />
+    <button mat-button class="edit-cover-picture-btn" *ngIf="userCoverPhotoURL==userInState.coverPhotoURL">
+      <input single type="file" id="cover-picture" class="cover-hidden-input" accept="image/x-png,image/jpeg"
+        (change)="onCoverFileSelected($event)" />
       <label for="cover-photo">
         <mat-icon>add_a_photo</mat-icon>
         <span class="edit-cover-pic-text">Edit Cover Photo</span>
       </label>
-
     </button>
 
-    <div class="profile-picture">
-      <img [src]="userPhotoURL" alt="profile picture" class="profile-pic" />
-      <button mat-icon-button class="edit-profile-pic" *ngIf="userPhotoURL==userInState.avatarURL">
+    <button mat-icon-button class="edit-cover-picture-btn cancel-button"
+      *ngIf="userCoverPhotoURL!==userInState.coverPhotoURL">
+      <input single class="cover-hidden-input" />
+      <label for="cover-picture">
+        <mat-icon (click)="cancelCoverPhoto()">close</mat-icon>
+      </label>
+    </button>
+
+    <div class="profile-picture-container">
+      <img [src]="userPhotoURL" class="profile-pic-img" alt="profile picture" />
+      <button mat-icon-button class="edit-profile-pic-btn" *ngIf="userPhotoURL==userInState.avatarURL">
         <input single type="file" id="profile-picture" style="display: none;" accept="image/x-png,image/jpeg"
-          (change)="onFileSelected($event)" />
+          (change)="onPhotoFileSelected($event)" />
         <label for="profile-picture">
           <mat-icon>add_a_photo</mat-icon>
         </label>
       </button>
 
-      <button mat-icon-button class="edit-profile-pic cancel-button" *ngIf="userPhotoURL!==userInState.avatarURL">
+      <button mat-icon-button class="edit-profile-pic-btn cancel-button" *ngIf="userPhotoURL!==userInState.avatarURL">
         <input single style="display: none;" />
         <label for="profile-picture">
           <mat-icon (click)="cancelPhoto()">close</mat-icon>
@@ -32,7 +43,8 @@
     </div>
   </div>
   <div class="form-error-messages" *ngIf="pictureErrMessage">{{pictureErrMessage}}</div>
-  <div class="form-error-messages" *ngIf="editProfileForm.invalid">
+  <div class="form-error-messages" *ngIf="coverErrMessage && !pictureErrMessage">{{coverErrMessage}}</div>
+  <div class="form-error-messages" *ngIf="editProfileForm.invalid && !coverErrMessage && !pictureErrMessage">
     {{ showErrorMessage() }}
   </div>
 

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -4,15 +4,23 @@
       <mat-icon>close</mat-icon>
     </button>
     <button mat-button class="edit-cover-picture">
-      <mat-icon>add_a_photo</mat-icon>
-      <span class="edit-cover-pic-text">Edit Cover Photo</span>
+      <input single type="file" id="cover-photo" style="display: none;" />
+      <label for="cover-photo">
+        <mat-icon>add_a_photo</mat-icon>
+        <span class="edit-cover-pic-text">Edit Cover Photo</span>
+      </label>
+
     </button>
 
     <div class="profile-picture">
       <img src="https://ollienollie.files.wordpress.com/2009/10/untitled-181.jpg" alt="profile picture"
         class="profile-pic" />
       <button mat-icon-button class="edit-profile-pic">
-        <mat-icon>add_a_photo</mat-icon>
+        <input single type="file" id="profile-picture" style="display: none;" />
+        <label for="profile-picture">
+          <mat-icon>add_a_photo</mat-icon>
+        </label>
+
       </button>
     </div>
   </div>

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -13,7 +13,7 @@
     </button>
 
     <div class="profile-picture">
-      <img src="{{userPhotoURL}}" alt="profile picture" class="profile-pic" />
+      <img [src]="userPhotoURL" alt="profile picture" class="profile-pic" />
       <button mat-icon-button class="edit-profile-pic">
         <input single type="file" id="profile-picture" style="display: none;" accept="image/x-png,image/jpeg"
           (change)="onFileSelected($event)" />
@@ -29,8 +29,7 @@
     {{ showErrorMessage() }}
   </div>
 
-
-  <form [formGroup]="editProfileForm" class="edit-profile-form">
+  <form [formGroup]="editProfileForm" class="edit-profile-form" (ngSubmit)="onSubmit()">
 
     <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
       <mat-label>First Name</mat-label>
@@ -57,11 +56,9 @@
       <mat-label>Confirm New Password</mat-label>
       <input matInput placeholder="Confirm New Password" type="password" [formControl]="newPwd2" />
     </mat-form-field>
-
+    <!-- <p>{{this.temporaryPhotoFile===null}}</p> -->
     <button class="mt-input-field secondary-action-btn" mat-flat-button type="submit"
-      [class.btn-opacity-disabled]="editProfileForm.invalid"
-      [disabled]="!editProfileForm.valid || !editProfileForm.touched || compareFormValues()">
-      Save Changes
+      [class.btn-opacity-disabled]="disableButton()" [disabled]="disableButton()">
     </button>
   </form>
 </div>

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -13,10 +13,10 @@
     </button>
 
     <div class="profile-picture">
-      <img src="{{userInDb.avatarURL}}" alt="profile picture"
-        class="profile-pic" />
+      <img src="{{userPhotoURL}}" alt="profile picture" class="profile-pic" />
       <button mat-icon-button class="edit-profile-pic">
-        <input single type="file" id="profile-picture" style="display: none;" />
+        <input single type="file" id="profile-picture" style="display: none;" accept="image/x-png,image/jpeg"
+          (change)="onFileSelected($event)" />
         <label for="profile-picture">
           <mat-icon>add_a_photo</mat-icon>
         </label>
@@ -24,10 +24,11 @@
       </button>
     </div>
   </div>
-
+  <div class="form-error-messages" *ngIf="pictureErrMessage">{{pictureErrMessage}}</div>
   <div class="form-error-messages" *ngIf="editProfileForm.invalid">
     {{ showErrorMessage() }}
   </div>
+
 
   <form [formGroup]="editProfileForm" class="edit-profile-form">
 

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -13,7 +13,7 @@
     </button>
 
     <div class="profile-picture">
-      <img src="https://ollienollie.files.wordpress.com/2009/10/untitled-181.jpg" alt="profile picture"
+      <img src="{{userInDb.avatarURL}}" alt="profile picture"
         class="profile-pic" />
       <button mat-icon-button class="edit-profile-pic">
         <input single type="file" id="profile-picture" style="display: none;" />

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -36,7 +36,7 @@
     <mat-form-field class="mt-input-field textarea bio" appearance="outline" color="coral">
       <mat-label>Bio</mat-label>
       <textarea matInput placeholder="Bio" matTextareaAutosize matAutosizeMinRows="5" matAutosizeMaxRows="10"
-        [formControl]="bio"></textarea>
+        [formControl]="biography"></textarea>
     </mat-form-field>
 
     <mat-form-field class="mt-input-field half" appearance="outline" color="coral">
@@ -51,7 +51,7 @@
 
     <button class="mt-input-field secondary-action-btn" mat-flat-button type="submit"
       [class.btn-opacity-disabled]="editProfileForm.invalid"
-      [disabled]="!editProfileForm.valid || !editProfileForm.touched">
+      [disabled]="!editProfileForm.valid || !editProfileForm.touched || compareFormValues()">
       Save Changes
     </button>
   </form>

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -14,14 +14,21 @@
 
     <div class="profile-picture">
       <img [src]="userPhotoURL" alt="profile picture" class="profile-pic" />
-      <button mat-icon-button class="edit-profile-pic">
+      <button mat-icon-button class="edit-profile-pic" *ngIf="userPhotoURL==userInState.avatarURL">
         <input single type="file" id="profile-picture" style="display: none;" accept="image/x-png,image/jpeg"
           (change)="onFileSelected($event)" />
         <label for="profile-picture">
           <mat-icon>add_a_photo</mat-icon>
         </label>
-
       </button>
+
+      <button mat-icon-button class="edit-profile-pic cancel-button" *ngIf="userPhotoURL!==userInState.avatarURL">
+        <input single style="display: none;" />
+        <label for="profile-picture">
+          <mat-icon (click)="cancelPhoto()">close</mat-icon>
+        </label>
+      </button>
+
     </div>
   </div>
   <div class="form-error-messages" *ngIf="pictureErrMessage">{{pictureErrMessage}}</div>
@@ -56,7 +63,7 @@
       <mat-label>Confirm New Password</mat-label>
       <input matInput placeholder="Confirm New Password" type="password" [formControl]="newPwd2" />
     </mat-form-field>
-    <!-- <p>{{this.temporaryPhotoFile===null}}</p> -->
+
     <button class="mt-input-field secondary-action-btn" mat-flat-button type="submit"
       [class.btn-opacity-disabled]="disableButton()" [disabled]="disableButton()"> Save Changes
     </button>

--- a/client/src/app/components/edit-profile/edit-profile.component.html
+++ b/client/src/app/components/edit-profile/edit-profile.component.html
@@ -58,7 +58,7 @@
     </mat-form-field>
     <!-- <p>{{this.temporaryPhotoFile===null}}</p> -->
     <button class="mt-input-field secondary-action-btn" mat-flat-button type="submit"
-      [class.btn-opacity-disabled]="disableButton()" [disabled]="disableButton()">
+      [class.btn-opacity-disabled]="disableButton()" [disabled]="disableButton()"> Save Changes
     </button>
   </form>
 </div>

--- a/client/src/app/components/edit-profile/edit-profile.component.scss
+++ b/client/src/app/components/edit-profile/edit-profile.component.scss
@@ -27,8 +27,8 @@
         width: 150px;
         border-radius: 50%;
         background: rgba(0, 0, 0, 0.5);
-        color: white;
         border: white solid 5px;
+        object-fit: cover;
       }
 
       .edit-profile-pic {
@@ -46,6 +46,10 @@
           position: absolute;
           font-size: 25px;
         }
+      }
+      .cancel-button {
+        background: rgba(0, 0, 0, 0.5);
+        -webkit-text-stroke-width: medium;
       }
     }
 

--- a/client/src/app/components/edit-profile/edit-profile.component.scss
+++ b/client/src/app/components/edit-profile/edit-profile.component.scss
@@ -1,12 +1,16 @@
 @import "../../../styles.scss";
 .container {
   max-width: 575px;
-  .cover-picture {
+  .photos-container {
     height: 350px;
-    background: center;
-    background-image: url(https://i.pinimg.com/originals/d7/0b/19/d70b19d883f6d08caccef02b8479fbbb.png);
     position: relative;
     border-radius: 5px;
+
+    .cover-pic-img {
+      height: 350px;
+      width: 100%;
+      object-fit: cover;
+    }
 
     .close-dialog-icon {
       background: rgba(0, 0, 0, 0.5);
@@ -16,13 +20,13 @@
       top: 1rem;
     }
 
-    .profile-picture {
+    .profile-picture-container {
       position: absolute;
       left: 50%;
       transform: translateX(-50%);
       bottom: -50px;
 
-      .profile-pic {
+      .profile-pic-img {
         height: 150px;
         width: 150px;
         border-radius: 50%;
@@ -31,7 +35,7 @@
         object-fit: cover;
       }
 
-      .edit-profile-pic {
+      .edit-profile-pic-btn {
         height: 40px;
         width: 40px;
         background: rgba(0, 0, 0, 0.5);
@@ -45,27 +49,36 @@
           left: 7px;
           position: absolute;
           font-size: 25px;
+          vertical-align: middle;
         }
       }
       .cancel-button {
-        background: rgba(0, 0, 0, 0.5);
-        -webkit-text-stroke-width: medium;
+        background: rgba(0, 0, 0, 0.5);      
       }
     }
 
-    .edit-cover-picture {
+    .edit-cover-picture-btn {
       right: 1rem;
       bottom: 1rem;
       color: white;
       position: absolute;
       background: rgba(0, 0, 0, 0.5);
 
+      .cover-hidden-input {
+        position: absolute;
+        opacity: 0%;
+      }
       .edit-cover-pic-text {
         padding-left: 10px;
       }
-
+      .cancel-button {
+        background: rgba(0, 0, 0, 0.5);
+        width: -webkit-fill-available;
+        position: absolute;
+      }
       mat-icon {
         height: 30px;
+        vertical-align: middle;
       }
     }
   }
@@ -89,16 +102,16 @@
       margin-top: 8em;
     }
 
-    .cover-picture {
+    .photos-container {
       height: 36vh;
 
       .edit-cover-pic-text {
         display: none;
       }
-      .edit-profile-pic {
+      .edit-profile-pic-btn {
         right: 33vw;
       }
-      .profile-pic {
+      .profile-pic-img {
         width: 110px;
         height: 110px;
       }

--- a/client/src/app/components/edit-profile/edit-profile.component.scss
+++ b/client/src/app/components/edit-profile/edit-profile.component.scss
@@ -20,7 +20,7 @@
       position: absolute;
       left: 50%;
       transform: translateX(-50%);
-      bottom: -75px;
+      bottom: -50px;
 
       .profile-pic {
         height: 150px;
@@ -69,6 +69,11 @@
   .edit-profile-form {
     margin-top: 6em;
   }
+  .form-error-messages {
+    font-size: 14px;
+    margin-top: 40px;
+    max-width: 460px;
+  }
 }
 
 // mobile styling
@@ -77,7 +82,7 @@
     padding: 5px;
 
     .edit-profile-form {
-      margin-top: 5em;
+      margin-top: 8em;
     }
 
     .cover-picture {

--- a/client/src/app/components/edit-profile/edit-profile.component.spec.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.spec.ts
@@ -192,7 +192,6 @@ describe('EditProfileComponent', () => {
   });
 
   it('should show error message for non image file input', () => {
-    const fakeFile = new File([''], 'nonImageFile');
     Object.defineProperty(fakeFile, 'size', { value: 1024 * 1024 }); // good size this time
     Object.defineProperty(fakeFile, 'type', { value: 'nonImage' });
     component.temporaryPhotoFile = fakeFile;
@@ -209,7 +208,6 @@ describe('EditProfileComponent', () => {
   });
 
   it('should successfully show a good photo in the browser (before upload)', () => {
-    const fakeFile = new File([''], 'GoodImage');
     Object.defineProperty(fakeFile, 'size', { value: 1024 * 1024 }); // good size this time
     Object.defineProperty(fakeFile, 'type', { value: 'image/png' });
     component.temporaryPhotoFile = fakeFile;

--- a/client/src/app/components/edit-profile/edit-profile.component.spec.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.spec.ts
@@ -1,31 +1,37 @@
-import { DomSanitizer } from '@angular/platform-browser';
+import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditProfileComponent } from './edit-profile.component';
-import { Component, EventEmitter, Inject, Input } from '@angular/core';
-import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import {
+  MatDialogModule,
+  MatDialogRef,
+  MAT_DIALOG_DATA,
+} from '@angular/material/dialog';
 import {
   MATERIAL_MODULE_DEPENDENCIES,
   FORM_MODULE_DPENDENCEIES,
 } from '../../shared.module';
-import { User } from '../../interfaces/user';
-import { AppError } from '../../interfaces/app-error';
 import { FormBuilder } from '@angular/forms';
 
 describe('EditProfileComponent', () => {
   let component: EditProfileComponent;
   let fixture: ComponentFixture<EditProfileComponent>;
   const fb: FormBuilder = new FormBuilder();
+  URL.createObjectURL = jest.fn();
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MATERIAL_MODULE_DEPENDENCIES, FORM_MODULE_DPENDENCEIES],
+      imports: [
+        MATERIAL_MODULE_DEPENDENCIES,
+        FORM_MODULE_DPENDENCEIES,
+        MatDialogModule,
+      ],
       providers: [
         { provide: FormBuilder, useValue: fb },
         {
           provide: DomSanitizer,
           useValue: {
             sanitize: () => 'safeString',
-            bypassSecurityTrustHtml: () => 'safeString',
+            bypassSecurityTrustUrl: (imageUrl: string) => 'safeString',
           },
         },
         {
@@ -34,7 +40,16 @@ describe('EditProfileComponent', () => {
             close: (dialogResult: any) => {},
           },
         },
-        { provide: MAT_DIALOG_DATA, useValue: [] },
+        {
+          provide: MAT_DIALOG_DATA,
+          useValue: {
+            firstName: 'John',
+            lastName: 'Doe',
+            biography: null,
+            password: 'Qwerty@123',
+            avatarURL: 'avatarURLforJohn',
+          },
+        },
       ],
       declarations: [EditProfileComponent],
     }).compileComponents();
@@ -49,4 +64,237 @@ describe('EditProfileComponent', () => {
   it('should create', () => {
     expect(component).toBeTruthy();
   });
+
+  it('should emit the photoUpdate event only, if good photo was chosen but fields are not changed', () => {
+    spyOn(component.userPhotoUpdate, 'emit');
+    spyOn(component.userUpdate, 'emit');
+    const fakeFile = new File([''], 'largeImage.png');
+    component.temporaryPhotoFile = fakeFile;
+    fixture.detectChanges();
+    component.onSubmit();
+    fixture.detectChanges();
+    expect(component.userPhotoUpdate.emit).toHaveBeenCalledWith(fakeFile);
+    expect(component.userUpdate.emit).not.toHaveBeenCalled();
+  });
+
+  it('should emit the userUpdate event only, if photo was not chosen but fields are changed', () => {
+    spyOn(component.userPhotoUpdate, 'emit');
+    spyOn(component.userUpdate, 'emit');
+    component.firstName.setValue('jack');
+    component.lastName.setValue('brown');
+    component.biography.setValue('this is the bio str for jack brown');
+    component.newPwd.setValue('Qwer@123456');
+    component.newPwd2.setValue('Qwer@123456');
+    component.editProfileForm.markAllAsTouched();
+    fixture.detectChanges();
+    component.onSubmit();
+    fixture.detectChanges();
+    expect(component.userPhotoUpdate.emit).not.toHaveBeenCalled();
+    expect(component.userUpdate.emit).toHaveBeenCalledWith({
+      firstName: 'jack',
+      lastName: 'brown',
+      biography: 'this is the bio str for jack brown',
+      avatarURL: 'avatarURLforJohn',
+      password: 'Qwer@123456',
+    });
+  });
+
+  it('should emit both userUpdate and userPhotoUpdate events, if a good photo was chosen and some of the fields are changed', () => {
+    spyOn(component.userPhotoUpdate, 'emit');
+    spyOn(component.userUpdate, 'emit');
+    jest.useFakeTimers();
+
+    const fakeFile = new File([''], 'largeImage.png');
+    component.temporaryPhotoFile = fakeFile;
+    fixture.detectChanges();
+    fixture.detectChanges();
+
+    component.lastName.setValue('brown');
+    component.biography.setValue('this is the bio str for John brown');
+    fixture.detectChanges();
+    component.onSubmit();
+    fixture.detectChanges();
+    jest.advanceTimersByTime(1000);
+    expect(component.userPhotoUpdate.emit).toHaveBeenCalledWith(fakeFile);
+    expect(component.userUpdate.emit).toHaveBeenCalledWith({
+      firstName: 'John',
+      lastName: 'brown',
+      biography: 'this is the bio str for John brown',
+      avatarURL: 'avatarURLforJohn',
+      password: 'Qwerty@123',
+    });
+    expect(component.userPhotoUpdate.emit).toHaveBeenCalledTimes(1);
+    expect(component.userUpdate.emit).toHaveBeenCalledTimes(1);
+  });
+
+  it('should see the fields have changed if a form field is not the same as state value', () => {
+    expect(component.fieldsChanged()).toBe(false);
+    component.firstName.setValue('SomeOtherName');
+    expect(component.fieldsChanged()).toBe(true);
+  });
+
+  it('should show "required" error message for first name if user change it to empty', () => {
+    component.firstName.markAsTouched();
+    component.firstName.setValue('');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'First/Last name should not be empty.'
+    );
+  });
+
+  it('should show "length" error message for first name', () => {
+    component.firstName.markAsTouched();
+    component.firstName.setValue('ab');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'First/Last name should be of length 3-20 characters with no numbers/spaces.'
+    );
+  });
+
+  it('should show "length" error message for bio', () => {
+    component.biography.markAsTouched();
+    component.biography.setValue('ab');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'Bio has to between 10 to 250 characters.'
+    );
+  });
+
+  it('should show correct "pwd" error messages', () => {
+    component.newPwd.markAsTouched();
+    component.newPwd.setValue('Qwer@4');
+    component.newPwd2.markAsTouched();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'Password must contain at least 8 characters, including one number, one symbol, one lowercase and one uppercase letter, and no space.'
+    );
+    component.newPwd.markAsTouched();
+    component.newPwd.setValue('Qwer@1234');
+    fixture.detectChanges();
+    component.newPwd2.markAsTouched();
+    component.newPwd2.setValue('Q');
+    component.newPwd2.markAsDirty();
+    fixture.detectChanges();
+    component.newPwd.markAsTouched();
+    fixture.detectChanges();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'Passwords do not match, please check.'
+    );
+  });
+  it('should show "length" error message for bio', () => {
+    component.biography.markAsTouched();
+    component.biography.setValue('ab');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.editProfileForm.valid).toBe(false);
+    expect(component.showErrorMessage()).toEqual(
+      'Bio has to between 10 to 250 characters.'
+    );
+  });
+
+  it('should show error message for large image file input', () => {
+    const fakeFile = new File([''], 'largeImage');
+    Object.defineProperty(fakeFile, 'size', { value: 1024 * 1024 + 1 }); // ie: 1048577 whichi is >1048576
+    Object.defineProperty(fakeFile, 'type', { value: 'image/png' }); // ie: 1048577 whichi is >1048576
+    component.temporaryPhotoFile = fakeFile;
+    const event = {
+      target: { files: [fakeFile] },
+    };
+
+    fixture.detectChanges();
+    component.onFileSelected((event as unknown) as Event);
+    fixture.detectChanges();
+    expect(component.userPhotoURL).toEqual('avatarURLforJohn');
+    expect(component.pictureErrMessage).toBe(
+      'Photo must be smaller than 1.0 MB!'
+    );
+    expect(component.temporaryPhotoFile).toBe(null);
+  });
+
+  it('should show error message for non image file input', () => {
+    const fakeFile = new File([''], 'nonImageFile');
+    Object.defineProperty(fakeFile, 'size', { value: 1024 * 1024 }); // good size this time
+    Object.defineProperty(fakeFile, 'type', { value: 'nonImage' });
+    component.temporaryPhotoFile = fakeFile;
+    const event = {
+      target: { files: [fakeFile] },
+    };
+
+    fixture.detectChanges();
+    component.onFileSelected((event as unknown) as Event);
+    fixture.detectChanges();
+    expect(component.userPhotoURL).toEqual('avatarURLforJohn');
+    expect(component.pictureErrMessage).toBe(
+      'The photo must be a file of type: jpeg, png, jpg!'
+    );
+    expect(component.temporaryPhotoFile).toBe(null);
+  });
+
+  it('should successfully show a good photo in the browser (before upload)', () => {
+    const fakeFile = new File([''], 'GoodImage');
+    Object.defineProperty(fakeFile, 'size', { value: 1024 * 1024 }); // good size this time
+    Object.defineProperty(fakeFile, 'type', { value: 'image/png' });
+    component.temporaryPhotoFile = fakeFile;
+    const event = {
+      target: { files: [fakeFile] },
+    };
+
+    fixture.detectChanges();
+    component.onFileSelected((event as unknown) as Event);
+    fixture.detectChanges();
+    expect(component.userPhotoURL).toEqual('safeString'); // sanitized url
+    expect(component.pictureErrMessage).toBe(null);
+    expect(component.temporaryPhotoFile).toBe(fakeFile);
+  });
+
+  it('should validate photos', () => {
+    const fakeFile = new File([''], 'largeImage.png');
+    component.temporaryPhotoFile = fakeFile;
+    expect(component.goodPhotoLoaded()).toBe(true);
+  });
+
+  it('should disable submit button if form fields are not valid', () => {
+    component.firstName.markAsTouched();
+    component.firstName.setValue('');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.disableButton()).toBe(true);
+    component.firstName.markAsTouched();
+    component.firstName.setValue('Johnny');
+    component.lastName.markAsTouched();
+    fixture.detectChanges();
+    expect(component.disableButton()).toBe(false);
+    component.temporaryPhotoFile = null;
+    fixture.detectChanges();
+    expect(component.disableButton()).toBe(false);
+  });
+
+  it('should not let multiple clicks on submit button', () => {
+    component.submitted = true;
+    fixture.detectChanges();
+    expect(component.disableButton()).toBe(true);
+  });
+
+  it('should disable submission button on loading the component', () => {
+    fixture.detectChanges();
+    expect(component.disableButton()).toBe(true);
+  });
+
+  it('should remove the photo if user clicks on cancel photo button ', () => {
+    const fakeFile = new File([''], 'largeImage.png');
+    component.temporaryPhotoFile = fakeFile;
+    fixture.detectChanges();
+    component.cancelPhoto();
+    fixture.detectChanges();
+    expect(component.temporaryPhotoFile).toBe(null);
+    expect(component.userPhotoURL).toBe('avatarURLforJohn');
+  });
 });
+

--- a/client/src/app/components/edit-profile/edit-profile.component.spec.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.spec.ts
@@ -1,20 +1,43 @@
+import { DomSanitizer } from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditProfileComponent } from './edit-profile.component';
+import { Component, EventEmitter, Inject, Input } from '@angular/core';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import {
   MATERIAL_MODULE_DEPENDENCIES,
   FORM_MODULE_DPENDENCEIES,
 } from '../../shared.module';
+import { User } from '../../interfaces/user';
+import { AppError } from '../../interfaces/app-error';
+import { FormBuilder } from '@angular/forms';
 
 describe('EditProfileComponent', () => {
   let component: EditProfileComponent;
   let fixture: ComponentFixture<EditProfileComponent>;
+  const fb: FormBuilder = new FormBuilder();
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [MATERIAL_MODULE_DEPENDENCIES, FORM_MODULE_DPENDENCEIES],
-      declarations: [EditProfileComponent]
-    })
-      .compileComponents();
+      providers: [
+        { provide: FormBuilder, useValue: fb },
+        {
+          provide: DomSanitizer,
+          useValue: {
+            sanitize: () => 'safeString',
+            bypassSecurityTrustHtml: () => 'safeString',
+          },
+        },
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: (dialogResult: any) => {},
+          },
+        },
+        { provide: MAT_DIALOG_DATA, useValue: [] },
+      ],
+      declarations: [EditProfileComponent],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/client/src/app/components/edit-profile/edit-profile.component.spec.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.spec.ts
@@ -1,4 +1,4 @@
-import { DomSanitizer, SafeUrl } from '@angular/platform-browser';
+import { DomSanitizer} from '@angular/platform-browser';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { EditProfileComponent } from './edit-profile.component';
 import {

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -1,5 +1,4 @@
-import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
-
+import { Component, Inject } from '@angular/core';
 import {
   FormBuilder,
   FormGroup,
@@ -7,14 +6,8 @@ import {
   AbstractControl,
 } from '@angular/forms';
 import { User } from 'src/app/interfaces/user';
-
-// export interface ProfileData {
-//   firstName: string;
-//   lastName: string;
-//   password: string;
-//   biography: string;
-// }
-
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
+import { ProfileData } from '../../interfaces/profileData';
 @Component({
   selector: 'app-edit-profile',
   templateUrl: './edit-profile.component.html',
@@ -29,21 +22,27 @@ export class EditProfileComponent {
   bio: AbstractControl;
   newPwd: AbstractControl;
   newPwd2: AbstractControl;
-  constructor(fb: FormBuilder) {
+  dataFromDialog: User;
+  // currentUser$: Observable<User>;
+  constructor(
+    fb: FormBuilder,
+    public dialogRef: MatDialogRef<EditProfileComponent>,
+    @Inject(MAT_DIALOG_DATA) public data: ProfileData
+  ) {
     this.editProfileForm = fb.group(
       {
         firstName: [
-          '',
+          data.firstName,
           Validators.compose([
             Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
           ]),
         ],
         lastName: [
-          '',
+          data.lastName,
           Validators.compose([Validators.pattern(/^[a-zA-Z]{3,20}$/u)]),
         ],
         bio: [
-          '',
+          data.biography,
           Validators.compose([
             Validators.minLength(10),
             Validators.maxLength(250),
@@ -69,19 +68,6 @@ export class EditProfileComponent {
     this.newPwd2 = this.editProfileForm.controls.newPwd2;
   }
 
-  // onSubmit(): void {
-  //   if (this.editProfileForm.valid) {
-  //     const newUser: User = {
-  //       firstName: this.firstName.value,
-  //       lastName: this.lastName.value,
-  //       password: this.newPwd.value,
-  //       email: this.email.value,
-  //       username: this.username.value,
-  //     };
-  //     this.userSignup.emit(newUser);
-  //   }
-  // }
-
   getFirstErrorMessage(): string {
     if (
       this.newPwd2.dirty &&
@@ -102,7 +88,7 @@ export class EditProfileComponent {
           const allErrorNames = Object.keys(
             this.editProfileForm.get(field).errors
           );
-          const result = field + ',' + allErrorNames[0]; // the resslt would be for example "firstName,required"
+          const result = field + ',' + allErrorNames[0]; // the result would be for example "firstName,required"
           return result;
         }
       }

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -1,5 +1,4 @@
-import { UserService } from 'src/app/services/user/user.service';
-import { Component, EventEmitter, Inject, Input, Output } from '@angular/core';
+import { Component, EventEmitter, Inject, Input } from '@angular/core';
 import {
   FormBuilder,
   FormGroup,

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -1,22 +1,138 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, EventEmitter, Input, Output } from '@angular/core';
 
+import {
+  FormBuilder,
+  FormGroup,
+  Validators,
+  AbstractControl,
+} from '@angular/forms';
+import { User } from 'src/app/interfaces/user';
 
-export interface ProfileData {
-  firstName: string;
-  lastName: string;
-  password: string;
-  biography: string;
-}
+// export interface ProfileData {
+//   firstName: string;
+//   lastName: string;
+//   password: string;
+//   biography: string;
+// }
 
 @Component({
   selector: 'app-edit-profile',
   templateUrl: './edit-profile.component.html',
-  styleUrls: ['./edit-profile.component.scss']
+  styleUrls: ['./edit-profile.component.scss'],
 })
+export class EditProfileComponent {
+  // @Output() userSignup: EventEmitter<User> = new EventEmitter();
+  // @Input() appError: boolean;
+  editProfileForm: FormGroup;
+  firstName: AbstractControl;
+  lastName: AbstractControl;
+  bio: AbstractControl;
+  newPwd: AbstractControl;
+  newPwd2: AbstractControl;
+  constructor(fb: FormBuilder) {
+    this.editProfileForm = fb.group(
+      {
+        firstName: [
+          '',
+          Validators.compose([
+            Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
+          ]),
+        ],
+        lastName: [
+          '',
+          Validators.compose([Validators.pattern(/^[a-zA-Z]{3,20}$/u)]),
+        ],
+        bio: [
+          '',
+          Validators.compose([
+            Validators.minLength(10),
+            Validators.maxLength(250),
+          ]),
+        ],
+        newPwd: [
+          '',
+          Validators.compose([
+            Validators.pattern(
+              /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\d\s])[\S]{8,}$/u
+            ),
+          ]),
+        ],
+        newPwd2: '',
+      },
+      { validator: passwordMatch } // This would be a custom validator to check whether passwords matched.
+    );
 
-export class EditProfileComponent implements OnInit {
-  constructor( ) { }
-  ngOnInit(): void {
+    this.firstName = this.editProfileForm.controls.firstName;
+    this.lastName = this.editProfileForm.controls.lastName;
+    this.bio = this.editProfileForm.controls.bio;
+    this.newPwd = this.editProfileForm.controls.newPwd;
+    this.newPwd2 = this.editProfileForm.controls.newPwd2;
+  }
+
+  // onSubmit(): void {
+  //   if (this.editProfileForm.valid) {
+  //     const newUser: User = {
+  //       firstName: this.firstName.value,
+  //       lastName: this.lastName.value,
+  //       password: this.newPwd.value,
+  //       email: this.email.value,
+  //       username: this.username.value,
+  //     };
+  //     this.userSignup.emit(newUser);
+  //   }
+  // }
+
+  getFirstErrorMessage(): string {
+    if (
+      this.newPwd2.dirty &&
+      this.newPwd.valid &&
+      this.editProfileForm.hasError('pwdsDidntMatch')
+    ) {
+      return 'pwds,match';
+    }
+    // Only 1 error msg is shown at a time, the first input field error is prior to second, and same for next ones
+    if (this.editProfileForm.touched && this.editProfileForm.invalid) {
+      for (const field in this.editProfileForm.controls) {
+        if (
+          this.editProfileForm.get(field).invalid &&
+          this.editProfileForm.get(field).touched
+        ) {
+          // all failed validators are available in control.errors which is an object
+          // and to get the names of failed validators we need the keys in errors Object
+          const allErrorNames = Object.keys(
+            this.editProfileForm.get(field).errors
+          );
+          const result = field + ',' + allErrorNames[0]; // the resslt would be for example "firstName,required"
+          return result;
+        }
+      }
+    }
+  }
+  showErrorMessage(): string {
+    const failedValidator = this.getFirstErrorMessage();
+
+    // to go around null errors in console for when we dont have any failed validators.
+    if (failedValidator) {
+      switch (failedValidator) {
+        case 'firstName,pattern':
+        case 'lastName,pattern':
+          return 'First/Last name should be of length 3-20 characters with no numbers/spaces.';
+
+        case 'bio,maxlength':
+        case 'bio,minlength':
+          return 'Bio has to between 10 to 250 characters.';
+
+        case 'newPwd,pattern':
+          return 'Password must contain at least 8 characters, including one number, one symbol, one lowercase and one uppercase letter, and no space.';
+
+        case 'pwds,match':
+          return 'Passwords do not match, please check.';
+      }
+    }
   }
 }
-
+function passwordMatch(frm: FormGroup): { [key: string]: boolean } {
+  return frm.get('newPwd').value === frm.get('newPwd2').value
+    ? null
+    : { pwdsDidntMatch: true };
+}

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -83,15 +83,20 @@ export class EditProfileComponent {
     this.submitted = true;
     this.appError = null; // to disable the button when we have an appError and user tries to click multiple times
     if (this.temporaryPhotoFile) {
+      console.log('user photo update event will be fired!');
       this.userPhotoUpdate.emit(this.temporaryPhotoFile);
     }
-    const newUser: User = {
-      firstName: this.firstName.value,
-      lastName: this.lastName.value,
-      password: this.newPwd.value,
-      biography: this.biography.value,
-    };
-    this.userUpdate.emit(newUser);
+    if (this.valuesChanged) {
+      const updatedUser = { ...this.userInState };
+      if (this.newPwd.value) {
+        updatedUser.password = this.newPwd.value;
+      }
+      updatedUser.firstName = this.firstName.value;
+      updatedUser.lastName = this.lastName.value;
+      updatedUser.password = this.newPwd.value;
+      updatedUser.biography = this.biography.value;
+      this.userUpdate.emit(updatedUser);
+    }
   }
 
   getFirstErrorMessage(): string {

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -6,7 +6,7 @@ import {
   AbstractControl,
 } from '@angular/forms';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
-import { ProfileData } from '../../interfaces/profileData';
+import { User } from '../../interfaces/user';
 @Component({
   selector: 'app-edit-profile',
   templateUrl: './edit-profile.component.html',
@@ -24,22 +24,22 @@ export class EditProfileComponent {
   constructor(
     fb: FormBuilder,
     public dialogRef: MatDialogRef<EditProfileComponent>,
-    @Inject(MAT_DIALOG_DATA) public data: ProfileData
+    @Inject(MAT_DIALOG_DATA) public userInDb: User
   ) {
     this.editProfileForm = fb.group(
       {
         firstName: [
-          data.firstName,
+          userInDb.firstName,
           Validators.compose([
             Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
           ]),
         ],
         lastName: [
-          data.lastName,
+          userInDb.lastName,
           Validators.compose([Validators.pattern(/^[a-zA-Z]{3,20}$/u)]),
         ],
         biography: [
-          data.biography,
+          userInDb.biography,
           Validators.compose([
             Validators.minLength(10),
             Validators.maxLength(250),
@@ -115,10 +115,10 @@ export class EditProfileComponent {
   }
   compareFormValues(): boolean {
     return (
-      this.firstName.value === this.data.firstName &&
-      this.lastName.value === this.data.lastName &&
-      (!this.newPwd.dirty) &&
-      this.biography.value === this.data.biography
+      this.firstName.value === this.userInDb.firstName &&
+      this.lastName.value === this.userInDb.lastName &&
+      !this.newPwd.dirty &&
+      this.biography.value === this.userInDb.biography
     );
   }
 }

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -103,7 +103,6 @@ export class EditProfileComponent {
       }
       updatedUser.firstName = this.firstName.value;
       updatedUser.lastName = this.lastName.value;
-      updatedUser.password = this.newPwd.value;
       updatedUser.biography = this.biography.value;
       this.userUpdate.emit(updatedUser);
     }
@@ -223,7 +222,6 @@ export class EditProfileComponent {
   cancelPhoto(): void {
     this.temporaryPhotoFile = null;
     this.userPhotoURL = this.userInState.avatarURL;
-    console.log('remove photo clicked');
   }
 }
 

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -21,6 +21,9 @@ export class EditProfileComponent {
   biography: AbstractControl;
   newPwd: AbstractControl;
   newPwd2: AbstractControl;
+  userPhotoURL: string | ArrayBuffer;
+  temporaryPhotoFile: File;
+  pictureErrMessage: string;
   constructor(
     fb: FormBuilder,
     public dialogRef: MatDialogRef<EditProfileComponent>,
@@ -57,7 +60,7 @@ export class EditProfileComponent {
       },
       { validator: passwordMatch } // This would be a custom validator to check whether passwords matched.
     );
-
+    this.userPhotoURL = userInDb.avatarURL;
     this.firstName = this.editProfileForm.controls.firstName;
     this.lastName = this.editProfileForm.controls.lastName;
     this.biography = this.editProfileForm.controls.biography;
@@ -120,6 +123,26 @@ export class EditProfileComponent {
       !this.newPwd.dirty &&
       this.biography.value === this.userInDb.biography
     );
+  }
+  onFileSelected(event: Event): void {
+    this.temporaryPhotoFile = (event.target as HTMLInputElement).files[0];
+    const size = this.temporaryPhotoFile.size;
+    const type = this.temporaryPhotoFile.type;
+    if (type !== 'image/jpeg' && type !== 'image/png') {
+      this.pictureErrMessage =
+        'The photo must be a file of type: jpeg, png, jpg!';
+      this.userPhotoURL = this.userInDb.avatarURL;
+      return;
+    } else if (size > 1000000) {
+      this.pictureErrMessage = 'Photo must be smaller than 1.0 MB!';
+      this.userPhotoURL = this.userInDb.avatarURL;
+      return;
+    }
+    const reader = new FileReader();
+    reader.onload = (e) => (this.userPhotoURL = reader.result);
+    reader.readAsDataURL(this.temporaryPhotoFile);
+    this.userPhotoURL = URL.createObjectURL(this.temporaryPhotoFile);
+    this.pictureErrMessage = null; // image type/size is valid
   }
 }
 function passwordMatch(frm: FormGroup): { [key: string]: boolean } {

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -46,11 +46,15 @@ export class EditProfileComponent {
           userInState.firstName, // initial value from current user in state
           Validators.compose([
             Validators.pattern(/^[a-zA-Z]{3,20}$/u), // validate the pattern to match this regex
+            Validators.required,
           ]),
         ],
         lastName: [
           userInState.lastName,
-          Validators.compose([Validators.pattern(/^[a-zA-Z]{3,20}$/u)]),
+          Validators.compose([
+            Validators.pattern(/^[a-zA-Z]{3,20}$/u),
+            Validators.required,
+          ]),
         ],
         biography: [
           userInState.biography,
@@ -89,8 +93,7 @@ export class EditProfileComponent {
         }, 1000);
         // in case user is changing both the photo, and some of the fileds,
         // we have to wait for the general update to finish updating state and then emit this event
-      }
-      else{
+      } else {
         this.userPhotoUpdate.emit(this.temporaryPhotoFile);
       }
     }
@@ -140,6 +143,9 @@ export class EditProfileComponent {
     // to go around null errors in console for when we dont have any failed validators.
     if (failedValidator) {
       switch (failedValidator) {
+        case 'firstName,required':
+        case 'lastName,required':
+          return 'First/Last name should not be empty.';
         case 'firstName,pattern':
         case 'lastName,pattern':
           return 'First/Last name should be of length 3-20 characters with no numbers/spaces.';

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -5,7 +5,6 @@ import {
   Validators,
   AbstractControl,
 } from '@angular/forms';
-import { User } from 'src/app/interfaces/user';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { ProfileData } from '../../interfaces/profileData';
 @Component({
@@ -19,11 +18,9 @@ export class EditProfileComponent {
   editProfileForm: FormGroup;
   firstName: AbstractControl;
   lastName: AbstractControl;
-  bio: AbstractControl;
+  biography: AbstractControl;
   newPwd: AbstractControl;
   newPwd2: AbstractControl;
-  dataFromDialog: User;
-  // currentUser$: Observable<User>;
   constructor(
     fb: FormBuilder,
     public dialogRef: MatDialogRef<EditProfileComponent>,
@@ -41,7 +38,7 @@ export class EditProfileComponent {
           data.lastName,
           Validators.compose([Validators.pattern(/^[a-zA-Z]{3,20}$/u)]),
         ],
-        bio: [
+        biography: [
           data.biography,
           Validators.compose([
             Validators.minLength(10),
@@ -63,11 +60,11 @@ export class EditProfileComponent {
 
     this.firstName = this.editProfileForm.controls.firstName;
     this.lastName = this.editProfileForm.controls.lastName;
-    this.bio = this.editProfileForm.controls.bio;
+    this.biography = this.editProfileForm.controls.biography;
     this.newPwd = this.editProfileForm.controls.newPwd;
-    this.newPwd2 = this.editProfileForm.controls.newPwd2;
+    this.newPwd2 = this.editProfileForm.controls.newPwd2; // this function return false if user put old values in input fileds.
   }
-
+  onSubmit(): void {}
   getFirstErrorMessage(): string {
     if (
       this.newPwd2.dirty &&
@@ -104,8 +101,8 @@ export class EditProfileComponent {
         case 'lastName,pattern':
           return 'First/Last name should be of length 3-20 characters with no numbers/spaces.';
 
-        case 'bio,maxlength':
-        case 'bio,minlength':
+        case 'biography,maxlength':
+        case 'biography,minlength':
           return 'Bio has to between 10 to 250 characters.';
 
         case 'newPwd,pattern':
@@ -115,6 +112,14 @@ export class EditProfileComponent {
           return 'Passwords do not match, please check.';
       }
     }
+  }
+  compareFormValues(): boolean {
+    return (
+      this.firstName.value === this.data.firstName &&
+      this.lastName.value === this.data.lastName &&
+      (!this.newPwd.dirty) &&
+      this.biography.value === this.data.biography
+    );
   }
 }
 function passwordMatch(frm: FormGroup): { [key: string]: boolean } {

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -201,12 +201,11 @@ export class EditProfileComponent {
   }
 
   disableButton(): boolean {
-    if (!this.editProfileForm.valid) {
-      return true;
-    } else if (
-      !this.goodPhotoLoaded() &&
-      !!this.editProfileForm.valid &&
-      !this.fieldsChanged()
+    if (
+      !this.editProfileForm.valid ||
+      (!this.goodPhotoLoaded() &&
+        !!this.editProfileForm.valid &&
+        !this.fieldsChanged())
     ) {
       return true;
     }

--- a/client/src/app/components/edit-profile/edit-profile.component.ts
+++ b/client/src/app/components/edit-profile/edit-profile.component.ts
@@ -83,9 +83,16 @@ export class EditProfileComponent {
     this.submitted = true;
     this.appError = null; // to disable the button when we have an appError and user tries to click multiple times
     if (this.goodPhotoLoaded()) {
-      console.log('user photo update event will be fired!');
-      this.userPhotoUpdate.emit(this.temporaryPhotoFile);
-      this.temporaryPhotoFile = null;
+      if (this.fieldsChanged()) {
+        setTimeout(() => {
+          this.userPhotoUpdate.emit(this.temporaryPhotoFile);
+        }, 1000);
+        // in case user is changing both the photo, and some of the fileds,
+        // we have to wait for the general update to finish updating state and then emit this event
+      }
+      else{
+        this.userPhotoUpdate.emit(this.temporaryPhotoFile);
+      }
     }
     if (this.fieldsChanged()) {
       const updatedUser = { ...this.userInState };
@@ -160,7 +167,6 @@ export class EditProfileComponent {
         'The photo must be a file of type: jpeg, png, jpg!';
       this.userPhotoURL = this.userInState.avatarURL;
       this.temporaryPhotoFile = null;
-      console.log('photo successfully selected.');
       return;
     } else if (size > 1048576) {
       this.pictureErrMessage = 'Photo must be smaller than 1.0 MB!';
@@ -208,6 +214,11 @@ export class EditProfileComponent {
   sanitizeImageUrl(imageUrl: string): SafeUrl {
     // otherwise the browser will complaint about unsafe url
     return this.sanitizer.bypassSecurityTrustUrl(imageUrl);
+  }
+  cancelPhoto(): void {
+    this.temporaryPhotoFile = null;
+    this.userPhotoURL = this.userInState.avatarURL;
+    console.log('remove photo clicked');
   }
 }
 

--- a/client/src/app/components/header/header.component.html
+++ b/client/src/app/components/header/header.component.html
@@ -84,7 +84,7 @@
         <mat-icon id="menu-item-icon">trending_up</mat-icon>
         <span>Your Profile</span>
       </button>
-      <button mat-menu-item routerLink="/home" routerLinkActive="active">
+      <button mat-menu-item routerLink="/home" routerLinkActive="active" (click)="logout()">
         <mat-icon id="menu-item-icon">exit_to_app</mat-icon>
         <span>Log out</span>
       </button>

--- a/client/src/app/components/header/header.component.html
+++ b/client/src/app/components/header/header.component.html
@@ -49,7 +49,7 @@
     <figure>
       <img
         id="user-photo"
-        src="../../../assets/user-photo.png"
+        src="{{userPhotoUrl}}"
         alt="user-photo"
       />
       <figcaption class="figcaption-in-menu">

--- a/client/src/app/components/header/header.component.html
+++ b/client/src/app/components/header/header.component.html
@@ -49,7 +49,7 @@
     <figure>
       <img
         id="user-photo"
-        src="{{userPhotoUrl}}"
+        src="{{userPhotoURL}}"
         alt="user-photo"
       />
       <figcaption class="figcaption-in-menu">

--- a/client/src/app/components/header/header.component.ts
+++ b/client/src/app/components/header/header.component.ts
@@ -7,7 +7,7 @@ import { StoreFacadeService } from '../../store/store-facade.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent {
-  @Input() userPhotoUrl: string;
+  @Input() userPhotoURL: string;
   constructor(private storeFacade: StoreFacadeService) {}
 
   logout(): void {

--- a/client/src/app/components/header/header.component.ts
+++ b/client/src/app/components/header/header.component.ts
@@ -1,4 +1,4 @@
-import { Component } from '@angular/core';
+import { Component, Input } from '@angular/core';
 import { StoreFacadeService } from '../../store/store-facade.service';
 
 @Component({
@@ -7,6 +7,7 @@ import { StoreFacadeService } from '../../store/store-facade.service';
   styleUrls: ['./header.component.scss'],
 })
 export class HeaderComponent {
+  @Input() userPhotoUrl: string;
   constructor(private storeFacade: StoreFacadeService) {}
 
   logout(): void {

--- a/client/src/app/components/login-form/login-form.component.scss
+++ b/client/src/app/components/login-form/login-form.component.scss
@@ -13,10 +13,6 @@
     background-color: $action-color;
     color: black;
   }
-
-  .btn-opacity-disabled {
-    opacity: 0.7;
-  }
 }
 
 @media only screen and (max-width: 600px) {

--- a/client/src/app/components/signup-form/signup-form.component.scss
+++ b/client/src/app/components/signup-form/signup-form.component.scss
@@ -14,10 +14,6 @@
     color: black;
     margin-left: 5px;
   }
-
-  .btn-opacity-disabled {
-    opacity: 0.7;
-  }
 }
 
 @media only screen and (max-width: 600px) {

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -85,7 +85,6 @@ export class SignupFormComponent {
         password: this.pwd.value,
         email: this.email.value,
         username: this.username.value,
-        biography: '',
       };
       this.userSignup.emit(newUser);
     }

--- a/client/src/app/components/signup-form/signup-form.component.ts
+++ b/client/src/app/components/signup-form/signup-form.component.ts
@@ -85,6 +85,7 @@ export class SignupFormComponent {
         password: this.pwd.value,
         email: this.email.value,
         username: this.username.value,
+        biography: '',
       };
       this.userSignup.emit(newUser);
     }

--- a/client/src/app/interfaces/profileData.ts
+++ b/client/src/app/interfaces/profileData.ts
@@ -1,0 +1,6 @@
+export interface ProfileData {
+  firstName: string;
+  lastName: string;
+  password: string;
+  biography: string;
+}

--- a/client/src/app/interfaces/profileData.ts
+++ b/client/src/app/interfaces/profileData.ts
@@ -1,6 +1,5 @@
 export interface ProfileData {
   firstName: string;
   lastName: string;
-  password: string;
   biography: string;
 }

--- a/client/src/app/interfaces/profileData.ts
+++ b/client/src/app/interfaces/profileData.ts
@@ -1,5 +1,0 @@
-export interface ProfileData {
-  firstName: string;
-  lastName: string;
-  biography: string;
-}

--- a/client/src/app/interfaces/user.ts
+++ b/client/src/app/interfaces/user.ts
@@ -6,7 +6,7 @@ export interface User {
   firstName?: string;
   lastName?: string;
   username?: string;
-  avatarUrl?: string;
+  avatarURL?: string;
   email?: string;
   score?: number;
   rank?: number;

--- a/client/src/app/interfaces/user.ts
+++ b/client/src/app/interfaces/user.ts
@@ -7,6 +7,7 @@ export interface User {
   lastName?: string;
   username?: string;
   avatarURL?: string;
+  coverPhotoURL?: string;
   email?: string;
   score?: number;
   rank?: number;

--- a/client/src/app/interfaces/user.ts
+++ b/client/src/app/interfaces/user.ts
@@ -13,6 +13,7 @@ export interface User {
   balance?: number;
   password?: string;
   alpacaApiKey?: string;
+  biography?: string;
   follows?: User[];
   followers?: User[];
   portfolio?: Stock[];

--- a/client/src/app/pages/home/home.component.html
+++ b/client/src/app/pages/home/home.component.html
@@ -1,8 +1,8 @@
-<app-header></app-header>
+<app-header [userPhotoUrl]='userPhotoUrl'></app-header>
 <h1>Welcome to home page!</h1>
 <button mat-raised-button (click)="openDialog()">Edit Profile</button>
 
-<div *ngIf = "currentUser$ | async as user">
+<div *ngIf="currentUser$ | async as user">
     <h1>This is a test to see user state</h1>
     <div>{{user.firstName}}</div>
     <div>{{user.username}}</div>

--- a/client/src/app/pages/home/home.component.html
+++ b/client/src/app/pages/home/home.component.html
@@ -1,4 +1,4 @@
-<app-header [userPhotoUrl]='userPhotoUrl'></app-header>
+<app-header [userPhotoURL]='userPhotoURL'></app-header>
 <h1>Welcome to home page!</h1>
 <button mat-raised-button (click)="openDialog()">Edit Profile</button>
 

--- a/client/src/app/pages/home/home.component.spec.ts
+++ b/client/src/app/pages/home/home.component.spec.ts
@@ -15,8 +15,6 @@ describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
-  const mockUserService = {} as any;
-
   beforeEach(async () => {
     await TestBed.configureTestingModule({
       imports: [

--- a/client/src/app/pages/home/home.component.spec.ts
+++ b/client/src/app/pages/home/home.component.spec.ts
@@ -1,21 +1,48 @@
-import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { UserService } from 'src/app/services/user/user.service';
 import { HomeComponent } from './home.component';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
 import { HeaderComponent } from '../../components/header/header.component';
-import { MATERIAL_MODULE_DEPENDENCIES, NGRX_STORE_MODULE, FORM_MODULE_DPENDENCEIES } from '../../shared.module';
+import {
+  MATERIAL_MODULE_DEPENDENCIES,
+  NGRX_STORE_MODULE,
+  FORM_MODULE_DPENDENCEIES,
+} from '../../shared.module';
 import { StockSearchComponent } from '../../components/stock-search/stock-search.component';
+import { EditProfileComponent } from './../../components/edit-profile/edit-profile.component';
 import { RouterTestingModule } from '@angular/router/testing';
 
 describe('HomeComponent', () => {
   let component: HomeComponent;
   let fixture: ComponentFixture<HomeComponent>;
 
+  const mockUserService = {} as any;
+
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      imports: [MATERIAL_MODULE_DEPENDENCIES, FORM_MODULE_DPENDENCEIES, RouterTestingModule],
-      declarations: [ HomeComponent, HeaderComponent, StockSearchComponent ],
-      providers: NGRX_STORE_MODULE
-    })
-    .compileComponents();
+      imports: [
+        MATERIAL_MODULE_DEPENDENCIES,
+        FORM_MODULE_DPENDENCEIES,
+        RouterTestingModule,
+      ],
+      declarations: [
+        HomeComponent,
+        HeaderComponent,
+        StockSearchComponent,
+        EditProfileComponent,
+      ],
+      providers: [
+        NGRX_STORE_MODULE,
+        { provide: UserService, useValue: mockUserService },
+        {
+          provide: MatDialogRef,
+          useValue: {
+            close: (dialogResult: any) => {},
+          },
+        },
+        { provide: MAT_DIALOG_DATA, useValue: [] },
+      ],
+    }).compileComponents();
   });
 
   beforeEach(() => {

--- a/client/src/app/pages/home/home.component.spec.ts
+++ b/client/src/app/pages/home/home.component.spec.ts
@@ -1,4 +1,3 @@
-import { UserService } from 'src/app/services/user/user.service';
 import { HomeComponent } from './home.component';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { MatDialogRef, MAT_DIALOG_DATA } from '@angular/material/dialog';
@@ -33,7 +32,6 @@ describe('HomeComponent', () => {
       ],
       providers: [
         NGRX_STORE_MODULE,
-        { provide: UserService, useValue: mockUserService },
         {
           provide: MatDialogRef,
           useValue: {

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -38,23 +38,15 @@ export class HomeComponent implements OnInit {
       disableClose: true,
     });
 
+    // const updatedUser = { ...this.currentUser };
+
     dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {
-      this.userService
-        .updateProfilePictureURL(this.currentUser.id, imageFile)
-        .subscribe((res) => {
-          const updatedUser = { ...this.currentUser };
-          updatedUser.avatarURL = res.body.avatarURL;
-          this.storeFacade.updateUser(updatedUser);
-        });
+      this.storeFacade.updateProfilePictureURL(this.currentUser.id, imageFile);
     });
 
     dialogRef.componentInstance.userUpdate.subscribe(
       (updatedUserInfo: User) => {
-        this.userService
-          .updateUser(this.currentUser.id, updatedUserInfo)
-          .subscribe((res) => {
-            this.storeFacade.updateUser(res);
-          });
+        this.storeFacade.updateUser(updatedUserInfo);
       }
     );
   }

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -4,7 +4,6 @@ import { User } from 'src/app/interfaces/user';
 import { StoreFacadeService } from '../../store/store-facade.service';
 import { MatDialog } from '@angular/material/dialog';
 import { EditProfileComponent } from '../../components/edit-profile/edit-profile.component';
-import { ProfileData } from '../../interfaces/profileData';
 
 @Component({
   selector: 'app-home',
@@ -13,31 +12,24 @@ import { ProfileData } from '../../interfaces/profileData';
 })
 export class HomeComponent implements OnInit {
   currentUser$: Observable<User>;
-  profileData: ProfileData;
+  currentUser: User;
 
   constructor(
     private storeFacade: StoreFacadeService,
     public dialog: MatDialog
   ) {
-    this.profileData = {
-      // otherwise there would be an undefined error because of waiting for the currentUser values to fetch
-      firstName: '',
-      lastName: '',
-      biography: '',
-    };
+    this.currentUser = null; // otherwise there would be an undefined error because of waiting for the currentUser values to fetch
   }
 
   ngOnInit(): void {
     this.currentUser$ = this.storeFacade.currentUser$;
     this.currentUser$.subscribe((user: User) => {
       if (user) {
-        this.profileData.firstName = user.firstName;
-        this.profileData.lastName = user.lastName;
-        this.profileData.biography = user.biography;
+        this.currentUser = user;
       }
     });
   }
   openDialog(): void {
-    this.dialog.open(EditProfileComponent, { data: this.profileData });
+    this.dialog.open(EditProfileComponent, { data: this.currentUser });
   }
 }

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -4,23 +4,42 @@ import { User } from 'src/app/interfaces/user';
 import { StoreFacadeService } from '../../store/store-facade.service';
 import { MatDialog } from '@angular/material/dialog';
 import { EditProfileComponent } from '../../components/edit-profile/edit-profile.component';
+import { ProfileData } from '../../interfaces/profileData';
 
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
-  styleUrls: ['./home.component.scss']
+  styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
   currentUser$: Observable<User>;
+  profileData: ProfileData;
 
-  constructor(private storeFacade: StoreFacadeService, public dialog: MatDialog) {
-
-    this.currentUser$ = this.storeFacade.currentUser$;
+  constructor(
+    private storeFacade: StoreFacadeService,
+    public dialog: MatDialog
+  ) {
+    this.profileData = {
+      // otherwise there would be an undefined error because of waiting for the currentUser values to fetch
+      firstName: '',
+      lastName: '',
+      biography: '',
+      password: '',
+    };
   }
 
   ngOnInit(): void {
+    this.currentUser$ = this.storeFacade.currentUser$;
+    this.currentUser$.subscribe((user: User) => {
+      if (user) {
+        this.profileData.firstName = user.firstName;
+        this.profileData.lastName = user.lastName;
+        // this.profileData.biography = user.biography; TODO: add biography to the User interfce in FE and also to the backend user
+        this.profileData.password = user.password;
+      }
+    });
   }
   openDialog(): void {
-    this.dialog.open(EditProfileComponent);
+    this.dialog.open(EditProfileComponent, { data: this.profileData });
   }
 }

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -1,5 +1,5 @@
 import { UserService } from 'src/app/services/user/user.service';
-import { Component, Input, OnInit, Output } from '@angular/core';
+import { Component, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { User } from 'src/app/interfaces/user';
 import { StoreFacadeService } from '../../store/store-facade.service';
@@ -37,8 +37,6 @@ export class HomeComponent implements OnInit {
       data: this.currentUser,
       disableClose: true,
     });
-
-    // const updatedUser = { ...this.currentUser };
 
     dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {
       this.storeFacade.updateProfilePictureURL(this.currentUser.id, imageFile);

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -34,7 +34,7 @@ export class HomeComponent implements OnInit {
       if (user) {
         this.profileData.firstName = user.firstName;
         this.profileData.lastName = user.lastName;
-        // this.profileData.biography = user.biography; TODO: add biography to the User interfce in FE and also to the backend user
+        this.profileData.biography = user.biography;
         this.profileData.password = user.password;
       }
     });

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -24,7 +24,6 @@ export class HomeComponent implements OnInit {
       firstName: '',
       lastName: '',
       biography: '',
-      password: '',
     };
   }
 
@@ -35,7 +34,6 @@ export class HomeComponent implements OnInit {
         this.profileData.firstName = user.firstName;
         this.profileData.lastName = user.lastName;
         this.profileData.biography = user.biography;
-        this.profileData.password = user.password;
       }
     });
   }

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -1,4 +1,3 @@
-import { UserService } from 'src/app/services/user/user.service';
 import { Component, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { User } from 'src/app/interfaces/user';
@@ -11,14 +10,15 @@ import { EditProfileComponent } from '../../components/edit-profile/edit-profile
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
-  @Output() userPhotoUrl: string;
+  @Output() userPhotoURL: string;
+  @Output() coverPhotoURL: string;
+
   currentUser$: Observable<User>;
   currentUser: User;
 
   constructor(
     private storeFacade: StoreFacadeService,
-    public dialog: MatDialog,
-    private userService: UserService
+    public dialog: MatDialog
   ) {
     this.currentUser = null; // otherwise there would be an undefined error because of waiting for the currentUser values to fetch
   }
@@ -28,7 +28,8 @@ export class HomeComponent implements OnInit {
     this.currentUser$.subscribe((user: User) => {
       if (user) {
         this.currentUser = user;
-        this.userPhotoUrl = this.currentUser.avatarURL;
+        this.userPhotoURL = this.currentUser.avatarURL;
+        this.coverPhotoURL = this.currentUser.coverPhotoURL;
       }
     });
   }
@@ -38,8 +39,22 @@ export class HomeComponent implements OnInit {
     });
 
     dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {
-      this.storeFacade.updateProfilePictureURL(this.currentUser.id, imageFile);
+      this.storeFacade.updatePictureURL(
+        this.currentUser.id,
+        imageFile,
+        'avatarURL'
+      );
     });
+
+    dialogRef.componentInstance.userCoverPhotoUpdate.subscribe(
+      (imageFile: File) => {
+        this.storeFacade.updatePictureURL(
+          this.currentUser.id,
+          imageFile,
+          'coverPhotoURL'
+        );
+      }
+    );
 
     dialogRef.componentInstance.userUpdate.subscribe(
       (updatedUserInfo: User) => {

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -35,7 +35,6 @@ export class HomeComponent implements OnInit {
   openDialog(): void {
     const dialogRef = this.dialog.open(EditProfileComponent, {
       data: this.currentUser,
-      disableClose: true,
     });
 
     dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -1,22 +1,24 @@
-import { Component, OnInit } from '@angular/core';
+import { UserService } from 'src/app/services/user/user.service';
+import { Component, Input, OnInit, Output } from '@angular/core';
 import { Observable } from 'rxjs';
 import { User } from 'src/app/interfaces/user';
 import { StoreFacadeService } from '../../store/store-facade.service';
 import { MatDialog } from '@angular/material/dialog';
 import { EditProfileComponent } from '../../components/edit-profile/edit-profile.component';
-
 @Component({
   selector: 'app-home',
   templateUrl: './home.component.html',
   styleUrls: ['./home.component.scss'],
 })
 export class HomeComponent implements OnInit {
+  @Output() userPhotoUrl: string;
   currentUser$: Observable<User>;
   currentUser: User;
 
   constructor(
     private storeFacade: StoreFacadeService,
-    public dialog: MatDialog
+    public dialog: MatDialog,
+    private userService: UserService
   ) {
     this.currentUser = null; // otherwise there would be an undefined error because of waiting for the currentUser values to fetch
   }
@@ -26,10 +28,24 @@ export class HomeComponent implements OnInit {
     this.currentUser$.subscribe((user: User) => {
       if (user) {
         this.currentUser = user;
+        this.userPhotoUrl = this.currentUser.avatarURL;
       }
     });
   }
   openDialog(): void {
-    this.dialog.open(EditProfileComponent, { data: this.currentUser });
+    const dialogRef = this.dialog.open(EditProfileComponent, {
+      data: this.currentUser,
+      disableClose: true,
+    });
+
+    dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {
+      this.userService
+        .updateProfilePictureUrl(this.currentUser.id, imageFile)
+        .subscribe((res) => {
+          const updatedUser = { ...this.currentUser };
+          updatedUser.avatarURL = res.body.avatarURL;
+          this.storeFacade.updateUser(updatedUser);
+        });
+    });
   }
 }

--- a/client/src/app/pages/home/home.component.ts
+++ b/client/src/app/pages/home/home.component.ts
@@ -40,12 +40,22 @@ export class HomeComponent implements OnInit {
 
     dialogRef.componentInstance.userPhotoUpdate.subscribe((imageFile: File) => {
       this.userService
-        .updateProfilePictureUrl(this.currentUser.id, imageFile)
+        .updateProfilePictureURL(this.currentUser.id, imageFile)
         .subscribe((res) => {
           const updatedUser = { ...this.currentUser };
           updatedUser.avatarURL = res.body.avatarURL;
           this.storeFacade.updateUser(updatedUser);
         });
     });
+
+    dialogRef.componentInstance.userUpdate.subscribe(
+      (updatedUserInfo: User) => {
+        this.userService
+          .updateUser(this.currentUser.id, updatedUserInfo)
+          .subscribe((res) => {
+            this.storeFacade.updateUser(res);
+          });
+      }
+    );
   }
 }

--- a/client/src/app/services/api/api.service.ts
+++ b/client/src/app/services/api/api.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpHeaders } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { environment } from '../../../environments/environment';
 

--- a/client/src/app/services/api/api.service.ts
+++ b/client/src/app/services/api/api.service.ts
@@ -8,12 +8,9 @@ import { environment } from '../../../environments/environment';
 })
 export class ApiService {
   baseUrl = environment.apiURL;
-  httpOptions = {
-    headers: new HttpHeaders({ 'Content-Type': 'application/json' }),
-    observe: 'response' as 'response',
-  };
+  httpOptions = { observe: 'response' as 'response' };
 
-  constructor(private http: HttpClient) { }
+  constructor(private http: HttpClient) {}
 
   get(url: string): Observable<any> {
     return this.http.get(this.baseUrl + url, this.httpOptions);

--- a/client/src/app/services/user/user.service.spec.ts
+++ b/client/src/app/services/user/user.service.spec.ts
@@ -9,6 +9,7 @@ const fakeReponse: User = {
   lastName: 'Doe',
   username: 'john1',
   avatarURL: '',
+  coverPhotoURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/services/user/user.service.spec.ts
+++ b/client/src/app/services/user/user.service.spec.ts
@@ -8,7 +8,7 @@ const fakeReponse: User = {
   firstName: 'John',
   lastName: 'Doe',
   username: 'john1',
-  avatarUrl: '',
+  avatarURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -62,6 +62,8 @@ export class UserService {
   updateProfilePictureURL(userId: number, imageFile: File): Observable<any> {
     const body = new FormData();
     body.append('imageFile', imageFile);
-    return this.api.post('users/profile-picture/' + userId.toString(), body);
+    return this.api
+      .post('users/profile-picture/' + userId.toString(), body)
+      .pipe(map((res: Response) => this.userFormatter(res.body)));
   }
 }

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -45,6 +45,7 @@ export class UserService {
       lastName: response.lastName,
       username: response.username,
       avatarURL: response.avatarURL,
+      coverPhotoURL: response.coverPhotoURL,
       email: response.email,
       score: response.score,
       rank: response.rank,
@@ -59,9 +60,14 @@ export class UserService {
     return formattedUser;
   }
 
-  updateProfilePictureURL(userId: number, imageFile: File): Observable<any> {
+  updatePictureURL(
+    userId: number,
+    imageFile: File,
+    selection: string
+  ): Observable<any> {
     const body = new FormData();
     body.append('imageFile', imageFile);
+    body.append('selection', selection); // here selection must be either "avatarURL" or "coverPhotoURL"
     return this.api
       .post('users/profile-picture/' + userId.toString(), body)
       .pipe(map((res: Response) => this.userFormatter(res.body)));

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -58,4 +58,10 @@ export class UserService {
     };
     return formattedUser;
   }
+
+  updateProfilePictureUrl(userId: number, imageFile: File): Observable<any> {
+    const body = new FormData();
+    body.append('imageFile', imageFile);
+    return this.api.update('users/profile-picture/' + userId.toString(), body);
+  }
 }

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -59,7 +59,7 @@ export class UserService {
     return formattedUser;
   }
 
-  updateProfilePictureUrl(userId: number, imageFile: File): Observable<any> {
+  updateProfilePictureURL(userId: number, imageFile: File): Observable<any> {
     const body = new FormData();
     body.append('imageFile', imageFile);
     return this.api.update('users/profile-picture/' + userId.toString(), body);

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -54,6 +54,7 @@ export class UserService {
       followers: response.followers,
       portfolio: response.portfolio,
       transactions: response.transactions,
+      biography: response.biography,
     };
     return formattedUser;
   }

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -62,6 +62,6 @@ export class UserService {
   updateProfilePictureURL(userId: number, imageFile: File): Observable<any> {
     const body = new FormData();
     body.append('imageFile', imageFile);
-    return this.api.update('users/profile-picture/' + userId.toString(), body);
+    return this.api.post('users/profile-picture/' + userId.toString(), body);
   }
 }

--- a/client/src/app/services/user/user.service.ts
+++ b/client/src/app/services/user/user.service.ts
@@ -44,7 +44,7 @@ export class UserService {
       firstName: response.firstName,
       lastName: response.lastName,
       username: response.username,
-      avatarUrl: response.avatarUrl,
+      avatarURL: response.avatarURL,
       email: response.email,
       score: response.score,
       rank: response.rank,

--- a/client/src/app/store/actions/app.actions.ts
+++ b/client/src/app/store/actions/app.actions.ts
@@ -44,3 +44,8 @@ export const setAppError = createAction(
   '[User] App Error',
   props<{ errorMessage: AppError }>()
 );
+
+export const updateProfilePictureURL = createAction(
+  '[User] Photo URL updated for user',
+  props<{ id: number; image: File }>()
+);

--- a/client/src/app/store/actions/app.actions.ts
+++ b/client/src/app/store/actions/app.actions.ts
@@ -45,7 +45,7 @@ export const setAppError = createAction(
   props<{ errorMessage: AppError }>()
 );
 
-export const updateProfilePictureURL = createAction(
+export const updatePictureURL = createAction(
   '[User] Photo URL updated for user',
-  props<{ id: number; image: File }>()
+  props<{ id: number; image: File , typeSelection: string}>()
 );

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -32,7 +32,7 @@ const userInfo = {
   firstName: 'John',
   lastName: 'Doe',
   username: 'john1',
-  avatarUrl: '',
+  avatarURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/effects/app.effects.spec.ts
+++ b/client/src/app/store/effects/app.effects.spec.ts
@@ -33,6 +33,7 @@ const userInfo = {
   lastName: 'Doe',
   username: 'john1',
   avatarURL: '',
+  coverPhotoURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -108,12 +108,12 @@ export class Effects {
     )
   );
 
-  updateProfilePictureURL$: Observable<Action> = createEffect(() =>
+  updatePictureURL$: Observable<Action> = createEffect(() =>
     this.actions$.pipe(
-      ofType(appActions.updateProfilePictureURL),
+      ofType(appActions.updatePictureURL),
       switchMap((action) => {
         return this.userService
-          .updateProfilePictureURL(action.id, action.image)
+          .updatePictureURL(action.id, action.image, action.typeSelection)
           .pipe(
             map((data) => appActions.setCurrentUser({ user: data })),
             catchError((data) =>

--- a/client/src/app/store/effects/app.effects.ts
+++ b/client/src/app/store/effects/app.effects.ts
@@ -58,19 +58,16 @@ export class Effects {
     this.actions$.pipe(
       ofType(appActions.upadateUser),
       switchMap((action) => {
-        // This function will be changed when the backend refactos
-        return this.userService
-          .updateUser(action.user.id, action.user)
-          .pipe(
-            map((data) => appActions.setCurrentUser({ user: data })),
-            catchError((data) =>
-              of(
-                appActions.setAppError({
-                  errorMessage: this.mirrorError(data),
-                })
-              )
+        return this.userService.updateUser(action.user.id, action.user).pipe(
+          map((data) => appActions.setCurrentUser({ user: data })),
+          catchError((data) =>
+            of(
+              appActions.setAppError({
+                errorMessage: this.mirrorError(data),
+              })
             )
-          );
+          )
+        );
       })
     )
   );
@@ -111,6 +108,25 @@ export class Effects {
     )
   );
 
+  updateProfilePictureURL$: Observable<Action> = createEffect(() =>
+    this.actions$.pipe(
+      ofType(appActions.updateProfilePictureURL),
+      switchMap((action) => {
+        return this.userService
+          .updateProfilePictureURL(action.id, action.image)
+          .pipe(
+            map((data) => appActions.setCurrentUser({ user: data })),
+            catchError((data) =>
+              of(
+                appActions.setAppError({
+                  errorMessage: this.mirrorError(data),
+                })
+              )
+            )
+          );
+      })
+    )
+  );
   mirrorError(backendError): AppError {
     if (backendError && backendError.error) {
       const errorMessage: AppError = {

--- a/client/src/app/store/reducers/app.reducer.spec.ts
+++ b/client/src/app/store/reducers/app.reducer.spec.ts
@@ -29,7 +29,7 @@ const userInfo: User = {
   firstName: 'John',
   lastName: 'Doe',
   username: 'john1',
-  avatarUrl: '',
+  avatarURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/reducers/app.reducer.spec.ts
+++ b/client/src/app/store/reducers/app.reducer.spec.ts
@@ -30,6 +30,7 @@ const userInfo: User = {
   lastName: 'Doe',
   username: 'john1',
   avatarURL: '',
+  coverPhotoURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/store-facade.service.spec.ts
+++ b/client/src/app/store/store-facade.service.spec.ts
@@ -9,7 +9,7 @@ const userInfo = {
   firstName: 'John',
   lastName: 'Doe',
   username: 'john1',
-  avatarUrl: '',
+  avatarURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/store-facade.service.spec.ts
+++ b/client/src/app/store/store-facade.service.spec.ts
@@ -10,6 +10,7 @@ const userInfo = {
   lastName: 'Doe',
   username: 'john1',
   avatarURL: '',
+  coverPhotoURL: '',
   email: 'john1@gmail.com',
   score: 12,
   rank: 10000,

--- a/client/src/app/store/store-facade.service.ts
+++ b/client/src/app/store/store-facade.service.ts
@@ -60,4 +60,10 @@ export class StoreFacadeService {
   logCurrentUserOut(): void {
     this.store.dispatch(appActions.logCurrentUserOut());
   }
+
+  updateProfilePictureURL(userId: number, imageFile: File): void {
+    this.store.dispatch(
+      appActions.updateProfilePictureURL({ id: userId, image: imageFile })
+    );
+  }
 }

--- a/client/src/app/store/store-facade.service.ts
+++ b/client/src/app/store/store-facade.service.ts
@@ -61,9 +61,13 @@ export class StoreFacadeService {
     this.store.dispatch(appActions.logCurrentUserOut());
   }
 
-  updateProfilePictureURL(userId: number, imageFile: File): void {
+  updatePictureURL(userId: number, imageFile: File, selection: string): void {
     this.store.dispatch(
-      appActions.updateProfilePictureURL({ id: userId, image: imageFile })
+      appActions.updatePictureURL({
+        id: userId,
+        image: imageFile,
+        typeSelection: selection,
+      })
     );
   }
 }

--- a/client/src/forms.scss
+++ b/client/src/forms.scss
@@ -28,6 +28,9 @@
   font-weight: 500;
   position: absolute;
 }
+.btn-opacity-disabled {
+  opacity: 0.7;
+}
 
 input:-webkit-autofill,
 input:-webkit-autofill:hover,


### PR DESCRIPTION
 
# Related Issue
- #182 create edit profile page form logic

# Proposed changes
- Added logic to edit profile component and the dialog in the home page, using the two backend endpoints for user photo change and the general update user, a user can edit profile info as well as the photo.

# Additional Info
- I made this pr for a high-level review of how the logic was implemented, so there will be a couple of changes and unit/e2e tests for the components which will be added in a future commit.

# Reviewer(s)
@Alessandro100
