### PR TITLE
#272: Follow & Unfollow User Endpoint

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
@@ -129,7 +129,7 @@ public class UserController {
 
    @PostMapping("/{userId}/follow/{userToFollowId}")
    ResponseEntity<Long> followUser(@PathVariable Long userId, @PathVariable Long userToFollowId) {
-      Long id = userService.followUser(userId, userToFollowId);
+      Long id = this.userService.followUser(userId, userToFollowId);
 
       return ResponseEntity.ok(id);
    }
@@ -141,9 +141,9 @@ public class UserController {
     * @return A response object
     */
 
-   @DeleteMapping("/{userId}/follow/{userToUnfollowId}")
+   @DeleteMapping("/{userId}/unfollow/{userToUnfollowId}")
    ResponseEntity<Long> unfollowUser(@PathVariable Long userId, @PathVariable Long userToUnfollowId) {
-      Long id = userService.unfollowUser(userId, userToUnfollowId);
+      Long id = this.userService.unfollowUser(userId, userToUnfollowId);
 
       return ResponseEntity.ok(id);
    }

--- a/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/UserController.java
@@ -120,6 +120,34 @@ public class UserController {
       return ResponseEntity.ok(this.userService.editUserProfilePicture(userToUpdate, imageFile, selection));
    }
 
+   /**
+    * Following a user endpoint
+    * @param userId The ID of the user that is following a user
+    * @param userToFollowId The ID of the user to follow
+    * @return A response object
+    */
+
+   @PostMapping("/{userId}/follow/{userToFollowId}")
+   ResponseEntity<Long> followUser(@PathVariable Long userId, @PathVariable Long userToFollowId) {
+      Long id = userService.followUser(userId, userToFollowId);
+
+      return ResponseEntity.ok(id);
+   }
+
+   /**
+    * Unfollowing a user endpoint
+    * @param userId The ID of the user that is following a user
+    * @param userToUnfollowId The ID of the user to unfollow
+    * @return A response object
+    */
+
+   @DeleteMapping("/{userId}/follow/{userToUnfollowId}")
+   ResponseEntity<Long> unfollowUser(@PathVariable Long userId, @PathVariable Long userToUnfollowId) {
+      Long id = userService.unfollowUser(userId, userToUnfollowId);
+
+      return ResponseEntity.ok(id);
+   }
+
    @DeleteMapping("/delete-by-email/{email}")
    public ResponseEntity<Void> deleteUserByEmail(@Valid @PathVariable String email) {
       try {

--- a/backend/src/main/java/com/capstone/moneytree/model/node/User.java
+++ b/backend/src/main/java/com/capstone/moneytree/model/node/User.java
@@ -5,6 +5,7 @@ import lombok.*;
 import org.neo4j.ogm.annotation.NodeEntity;
 import org.neo4j.ogm.annotation.Relationship;
 
+import java.util.HashSet;
 import java.util.Set;
 
 @EqualsAndHashCode(callSuper = true)
@@ -39,7 +40,7 @@ public class User extends Entity {
 
     String biography;
 
-    @Relationship(type = "FOLLOWS", direction = Relationship.INCOMING)
+    @Relationship(type = "FOLLOWS")
     Set<User> followers;
 
     @Relationship(type = "OWNS")
@@ -48,12 +49,22 @@ public class User extends Entity {
     @Relationship(type = "MADE")
     Set<Transaction> transactions;
 
+    @Override
+    public int hashCode() {
+        return Math.toIntExact(this.getId());
+    }
+
     public void follow(User user) {
-        this.getFollowers().add(user);
+        if (followers == null) {
+            followers = new HashSet<>();
+        }
+        followers.add(user);
     }
 
     public void unfollow(User user) {
-        this.getFollowers().remove(user);
+        if (followers != null && !followers.isEmpty()) {
+            followers.remove(user);
+        }
     }
 
     public void made(Transaction transaction) {

--- a/backend/src/main/java/com/capstone/moneytree/model/node/User.java
+++ b/backend/src/main/java/com/capstone/moneytree/model/node/User.java
@@ -48,12 +48,12 @@ public class User extends Entity {
     @Relationship(type = "MADE")
     Set<Transaction> transactions;
 
-    public void follows(User user) {
-        user.getFollowers().add(this);
+    public void follow(User user) {
+        this.getFollowers().add(user);
     }
 
-    public void followedBy(User user) {
-        this.getFollowers().add(user);
+    public void unfollow(User user) {
+        this.getFollowers().remove(user);
     }
 
     public void made(Transaction transaction) {

--- a/backend/src/main/java/com/capstone/moneytree/model/node/User.java
+++ b/backend/src/main/java/com/capstone/moneytree/model/node/User.java
@@ -50,6 +50,16 @@ public class User extends Entity {
     Set<Transaction> transactions;
 
     @Override
+    public boolean equals(Object object) {
+        if (object instanceof User){
+            User other = (User) object;
+            return this.getId().equals(other.getId());
+        }
+
+        return false;
+    }
+
+    @Override
     public int hashCode() {
         return Math.toIntExact(this.getId());
     }

--- a/backend/src/main/java/com/capstone/moneytree/service/api/UserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/api/UserService.java
@@ -42,6 +42,10 @@ public interface UserService {
 
    User editUserProfilePicture(User user, MultipartFile imageFile, String selection);
 
+   Long followUser(Long userId, Long userToFollowId);
+
+   Long unfollowUser(Long userId, Long userToUnfollowId);
+
    void deleteUserByEmail(String email);
 
 }

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -236,6 +236,34 @@ public class DefaultUserService implements UserService {
    }
 
    @Override
+   public Long followUser(Long userId, Long userToFollowId) {
+      User user = userDao.findUserById(userId);
+      User userToFollow = userDao.findUserById(userToFollowId);
+      if (user == null || userToFollow == null) {
+         throw new EntityNotFoundException(USER_NOT_FOUND);
+      }
+
+      user.follow(userToFollow);
+      userDao.save(user);
+
+      return userToFollowId;
+   }
+
+   @Override
+   public Long unfollowUser(Long userId, Long userToUnfollowId) {
+      User user = userDao.findUserById(userId);
+      User userToUnfollow = userDao.findUserById(userToUnfollowId);
+      if (user == null || userToUnfollow == null) {
+         throw new EntityNotFoundException(USER_NOT_FOUND);
+      }
+
+      user.unfollow(userToUnfollow);
+      userDao.save(user);
+
+      return userToUnfollowId;
+   }
+
+   @Override
    public void deleteUserByEmail(String email) {
       User existingUser = userDao.findUserByEmail(email);
       if (existingUser == null) {

--- a/backend/src/test/groovy/com/capstone/moneytree/model/node/UserTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/model/node/UserTest.groovy
@@ -1,0 +1,59 @@
+package com.capstone.moneytree.model.node
+
+import static com.capstone.moneytree.utils.MoneyTreeTestUtils.*
+
+import org.junit.Test
+import spock.lang.Specification
+
+/**
+ * Unit Tests for the User model.
+ */
+class UserTest extends Specification {
+
+    private static User user
+
+    def setup() {
+        user = createUser(1, "test@test.com", "username", "password", "Jake", "Moreau", "123B")
+    }
+
+    @Test
+    def "Should follow a user"() {
+        given: "another user"
+        User user2 = createUser(2, "test2@test.com", "username2", "password2", "Will", "Moreau", "123C")
+
+        when: "follow another user"
+        user.follow(user2)
+
+        then: "should be added to the followers"
+        assert user.getFollowers().size() == 1
+        assert user.getFollowers().contains(user2)
+    }
+
+    @Test
+    def "Should unfollow a user"() {
+        given: "another user"
+        User user2 = createUser(2, "test2@test.com", "username2", "password2", "Will", "Moreau", "123C")
+
+        when: "unfollow another user already followed by user1"
+        Set<User> followers = new HashSet<>();
+        followers.add(user2)
+        user.setFollowers(followers)
+        user.unfollow(user2)
+
+        then: "should be removed from the followers"
+        assert user.getFollowers().size() == 0
+    }
+
+    @Test
+    def "Should create a new set of followers if following first person ever"() {
+        given: "another user"
+        User user2 = createUser(2, "test2@test.com", "username2", "password2", "Will", "Moreau", "123C")
+
+        assert user2.getFollowers() == null
+        when: "follow another user by creating a fresh set for followers"
+        user.follow(user2)
+
+        then: "should be added to the followers"
+        assert user.getFollowers().size() == 1
+    }
+}

--- a/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
@@ -5,9 +5,9 @@ import com.capstone.moneytree.model.node.User
 class MoneyTreeTestUtils {
 
    /**
-    * Utility method to create a user
+    * Utility method to create a user with random ID
     */
-   static User createUser(Long id = new Random().nextLong(), String email, String username, String password, String firstName, String lastName, String alpacaApiKey) {
+   static User createUser(String email, String username, String password, String firstName, String lastName, String alpacaApiKey) {
       User user = User.builder()
               .email(email)
               .username(username)
@@ -16,7 +16,23 @@ class MoneyTreeTestUtils {
               .lastName(lastName)
               .alpacaApiKey(alpacaApiKey)
               .build()
-      user.setId(id)
+      user.setId(new Random().nextLong())
+      return user
+   }
+
+   /**
+    * Utility method to create a user
+    */
+   static User createUser(Long id, String email, String username, String password, String firstName, String lastName, String alpacaApiKey) {
+      User user = User.builder()
+              .email(email)
+              .username(username)
+              .password(password)
+              .firstName(firstName)
+              .lastName(lastName)
+              .alpacaApiKey(alpacaApiKey)
+              .build();
+      user.setId(id);
       return user
    }
 


### PR DESCRIPTION
 
# Related Issue
- #272 

# Proposed changes
- Follow User Endpoint: **POST** request on endpoint  `/api/users/{userId}/follow/{userIdFollower}` where userId wants to follow userIdFollower
- Unfollow User Endpoint: **DELETE** request on endpoint `/api/users/{userId}/unfollow/{userIdFollower}` where userId wants to unfollow userIdFollower
- Unit tests and integration tests

# Additional Info
- Changed the way we return the hash code for the users to be able to compare them with their ID. Working with Sets allows us to do that and it makes it easier to compare Users into the followers set.

# Checklist (if applicable)
- [x] Tests

# Screenshots

We can follow multiple people amongst other people. Relationships are created in neo4j. Here, user named t follows other people.
![follows](https://user-images.githubusercontent.com/37888675/106850981-74b99380-6683-11eb-99d8-a26b26bbecd6.png)

We can unfollow people and it deletes the relationship where t unfollows Razine.
![unfollow](https://user-images.githubusercontent.com/37888675/106851016-869b3680-6683-11eb-874b-1011eaed0be8.png)

# Reviewer(s)
 - @razine-bensari 
 - @abdulmansour 
 - @wltrf 
 - @Alessandro100 