### PR TITLE
Implement Yahoo finance proxy for hist data #266

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -61,6 +61,15 @@
             <version>2.4.2</version>
         </dependency>
         <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-webflux</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-gateway-mvc</artifactId>
+            <version>3.0.1</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <optional>true</optional>

--- a/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
@@ -102,17 +102,8 @@ public class StockController {
    Valid ranges: [1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max]
    Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]
    */
-   @GetMapping(value = "/chart1/{symbol}", produces = {"application/json"})
-   public Mono<String> getChart1(@PathVariable String symbol, @RequestParam String range, @RequestParam String interval){
+   @GetMapping(value = "/yahooChart/{symbol}", produces = {"application/json"})
+   public Mono<String> getYahooChart(@PathVariable String symbol, @RequestParam String range, @RequestParam String interval){
       return yahooFinanceService.getHistoricalGraphData(symbol, range, interval);
-   }
-   
-   /*
-   Valid ranges: [1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max]
-   Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]
-   */
-   @GetMapping(value = "/chart2/{symbol}", produces = {"application/json"})
-   public ResponseEntity<String> getChart2(ProxyExchange<String> proxy, @PathVariable String symbol, @RequestParam String range, @RequestParam String interval) {
-      return proxy.uri("https://query1.finance.yahoo.com/v8/finance/chart/" + symbol + "?range=" + range + "&interval=" + interval).get();
    }
 }

--- a/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
@@ -6,13 +6,13 @@ import javax.validation.Valid;
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.Size;
 
+import com.capstone.moneytree.service.api.YahooFinanceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.*;
 
 import com.capstone.moneytree.service.api.StockMarketDataService;
 
@@ -24,18 +24,21 @@ import pl.zankowski.iextrading4j.api.stocks.Quote;
 import pl.zankowski.iextrading4j.api.stocks.v1.BatchStocks;
 import pl.zankowski.iextrading4j.api.stocks.v1.KeyStats;
 import pl.zankowski.iextrading4j.api.stocks.v1.News;
+import reactor.core.publisher.Mono;
 
 @MoneyTreeController
 @RequestMapping("/stockmarket")
 public class StockController {
 
 
-   private StockMarketDataService stockMarketDataService;
+   private final StockMarketDataService stockMarketDataService;
+   private final YahooFinanceService yahooFinanceService;
 
    private static final Logger LOG = LoggerFactory.getLogger(StockController.class);
 
    @Autowired
-   public StockController(StockMarketDataService stockMarketDataService) {
+   public StockController(StockMarketDataService stockMarketDataService, YahooFinanceService yahooFinanceService) {
+      this.yahooFinanceService = yahooFinanceService;
       LOG.info("Initializing StockController");
       this.stockMarketDataService = stockMarketDataService;
    }
@@ -93,5 +96,23 @@ public class StockController {
    public ResponseEntity<Logo> getLogo(@PathVariable(name = "symbol") @Valid @NotBlank @Size(max = 5) String symbol) {
       Logo logo = stockMarketDataService.getLogo(symbol);
       return ResponseEntity.ok(logo);
+   }
+
+   /*
+   Valid ranges: [1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max]
+   Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]
+   */
+   @GetMapping(value = "/chart1/{symbol}", produces = {"application/json"})
+   public Mono<String> getChart1(@PathVariable String symbol, @RequestParam String range, @RequestParam String interval){
+      return yahooFinanceService.getHistoricalGraphData(symbol, range, interval);
+   }
+   
+   /*
+   Valid ranges: [1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max]
+   Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]
+   */
+   @GetMapping(value = "/chart2/{symbol}", produces = {"application/json"})
+   public ResponseEntity<String> getChart2(ProxyExchange<String> proxy, @PathVariable String symbol, @RequestParam String range, @RequestParam String interval) {
+      return proxy.uri("https://query1.finance.yahoo.com/v8/finance/chart/" + symbol + "?range=" + range + "&interval=" + interval).get();
    }
 }

--- a/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/StockController.java
@@ -1,30 +1,25 @@
 package com.capstone.moneytree.controller;
 
-import java.util.List;
-
-import javax.validation.Valid;
-import javax.validation.constraints.NotBlank;
-import javax.validation.constraints.Size;
-
+import com.capstone.moneytree.service.api.StockMarketDataService;
 import com.capstone.moneytree.service.api.YahooFinanceService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.cloud.gateway.mvc.ProxyExchange;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
-
-import com.capstone.moneytree.service.api.StockMarketDataService;
-
-import pl.zankowski.iextrading4j.api.stocks.Book;
-import pl.zankowski.iextrading4j.api.stocks.Chart;
-import pl.zankowski.iextrading4j.api.stocks.Company;
-import pl.zankowski.iextrading4j.api.stocks.Logo;
-import pl.zankowski.iextrading4j.api.stocks.Quote;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import pl.zankowski.iextrading4j.api.stocks.*;
 import pl.zankowski.iextrading4j.api.stocks.v1.BatchStocks;
 import pl.zankowski.iextrading4j.api.stocks.v1.KeyStats;
 import pl.zankowski.iextrading4j.api.stocks.v1.News;
 import reactor.core.publisher.Mono;
+
+import javax.validation.Valid;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.Size;
+import java.util.List;
 
 @MoneyTreeController
 @RequestMapping("/stockmarket")
@@ -102,7 +97,7 @@ public class StockController {
    Valid ranges: [1d, 5d, 1mo, 3mo, 6mo, 1y, 2y, 5y, 10y, ytd, max]
    Valid intervals: [1m, 2m, 5m, 15m, 30m, 60m, 90m, 1h, 1d, 5d, 1wk, 1mo, 3mo]
    */
-   @GetMapping(value = "/yahooChart/{symbol}", produces = {"application/json"})
+   @GetMapping(value = "/yahoochart/{symbol}", produces = {"application/json"})
    public Mono<String> getYahooChart(@PathVariable String symbol, @RequestParam String range, @RequestParam String interval){
       return yahooFinanceService.getHistoricalGraphData(symbol, range, interval);
    }

--- a/backend/src/main/java/com/capstone/moneytree/facade/YahooFinanceFacade.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/YahooFinanceFacade.java
@@ -1,0 +1,20 @@
+package com.capstone.moneytree.facade;
+
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+@Component
+public class YahooFinanceFacade {
+
+    private final WebClient webClient;
+
+    public YahooFinanceFacade(WebClient.Builder webClientBuilder) {
+        this.webClient = webClientBuilder.baseUrl("https://query1.finance.yahoo.com").build();
+    }
+
+    public Mono<String> getHistoricalGraphData(String ticker, String range, String interval) {
+        return this.webClient.get().uri("/v8/finance/chart/{ticker}?range={range}&interval={interval}", ticker, range, interval)
+                .retrieve().bodyToMono(String.class);
+    }
+}

--- a/backend/src/main/java/com/capstone/moneytree/facade/YahooFinanceFacade.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/YahooFinanceFacade.java
@@ -1,5 +1,6 @@
 package com.capstone.moneytree.facade;
 
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
@@ -9,6 +10,7 @@ public class YahooFinanceFacade {
 
     private final WebClient webClient;
 
+    @Autowired
     public YahooFinanceFacade(WebClient.Builder webClientBuilder) {
         this.webClient = webClientBuilder.baseUrl("https://query1.finance.yahoo.com").build();
     }

--- a/backend/src/main/java/com/capstone/moneytree/service/api/YahooFinanceService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/api/YahooFinanceService.java
@@ -1,0 +1,7 @@
+package com.capstone.moneytree.service.api;
+
+import reactor.core.publisher.Mono;
+
+public interface YahooFinanceService {
+    public Mono<String> getHistoricalGraphData(String ticker, String range, String interval);
+}

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultYahooFinanceService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultYahooFinanceService.java
@@ -1,0 +1,22 @@
+package com.capstone.moneytree.service.impl;
+
+import com.capstone.moneytree.facade.YahooFinanceFacade;
+import com.capstone.moneytree.service.api.YahooFinanceService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Service
+public class DefaultYahooFinanceService implements YahooFinanceService {
+    private final YahooFinanceFacade yahooFinanceFacade;
+
+    @Autowired
+    public DefaultYahooFinanceService(YahooFinanceFacade yahooFinanceFacade) {
+        this.yahooFinanceFacade = yahooFinanceFacade;
+    }
+
+    @Override
+    public Mono<String> getHistoricalGraphData(String ticker, String range, String interval) {
+        return yahooFinanceFacade.getHistoricalGraphData(ticker, range, interval);
+    }
+}

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultYahooFinanceService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultYahooFinanceService.java
@@ -8,12 +8,8 @@ import reactor.core.publisher.Mono;
 
 @Service
 public class DefaultYahooFinanceService implements YahooFinanceService {
-    private final YahooFinanceFacade yahooFinanceFacade;
-
     @Autowired
-    public DefaultYahooFinanceService(YahooFinanceFacade yahooFinanceFacade) {
-        this.yahooFinanceFacade = yahooFinanceFacade;
-    }
+    YahooFinanceFacade yahooFinanceFacade;
 
     @Override
     public Mono<String> getHistoricalGraphData(String ticker, String range, String interval) {

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerIT.groovy
@@ -11,7 +11,7 @@ import org.springframework.test.context.ActiveProfiles
 import com.capstone.moneytree.facade.StockMarketDataFacade
 import com.capstone.moneytree.service.api.StockMarketDataService
 import com.capstone.moneytree.service.impl.DefaultStockMarketDataService
-
+import org.springframework.web.reactive.function.client.WebClient
 import pl.zankowski.iextrading4j.api.exception.IEXTradingException
 import spock.lang.Ignore
 import spock.lang.Specification
@@ -28,8 +28,8 @@ class StockControllerIT extends Specification {
 
    StockMarketDataFacade stockMarketDataFacade = new StockMarketDataFacade(PUBLISH_TOKEN, SECRET_TOKEN, "dev")
    StockMarketDataService stockMarketDataService = new DefaultStockMarketDataService(stockMarketDataFacade: stockMarketDataFacade)
-   YahooFinanceFacade yahooFinanceFacade = new YahooFinanceFacade();
-   YahooFinanceService yahooFinanceService = new DefaultYahooFinanceService(yahooFinanceFacade);
+   YahooFinanceFacade yahooFinanceFacade = new YahooFinanceFacade(WebClient.builder());
+   YahooFinanceService yahooFinanceService = new DefaultYahooFinanceService(yahooFinanceFacade: yahooFinanceFacade);
    StockController stockController = new StockController(stockMarketDataService, yahooFinanceService)
 
    @Ignore("Fails, needs to be fixed")
@@ -258,7 +258,6 @@ class StockControllerIT extends Specification {
       def res = stockController.getYahooChart(symbol, range, interval)
 
       then: "We get a valid chart object"
-      res.statusCode == HttpStatus.OK
-      res.getBody() != null
+      res != null
    }
 }

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/StockControllerIT.groovy
@@ -1,5 +1,8 @@
 package com.capstone.moneytree.controller
 
+import com.capstone.moneytree.facade.YahooFinanceFacade
+import com.capstone.moneytree.service.api.YahooFinanceService
+import com.capstone.moneytree.service.impl.DefaultYahooFinanceService
 import org.junit.platform.commons.util.StringUtils
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.http.HttpStatus
@@ -14,7 +17,7 @@ import spock.lang.Ignore
 import spock.lang.Specification
 
 /**
- * Tests for the Stock Controller. Tests the StockMarketDataFacade as well.
+ * Tests for the Stock Controller. Tests the StockMarketDataFacade as well. Tests the YahooFinance facade and service.
  * */
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
 @ActiveProfiles("dev")
@@ -25,7 +28,9 @@ class StockControllerIT extends Specification {
 
    StockMarketDataFacade stockMarketDataFacade = new StockMarketDataFacade(PUBLISH_TOKEN, SECRET_TOKEN, "dev")
    StockMarketDataService stockMarketDataService = new DefaultStockMarketDataService(stockMarketDataFacade: stockMarketDataFacade)
-   StockController stockController = new StockController(stockMarketDataService)
+   YahooFinanceFacade yahooFinanceFacade = new YahooFinanceFacade();
+   YahooFinanceService yahooFinanceService = new DefaultYahooFinanceService(yahooFinanceFacade);
+   StockController stockController = new StockController(stockMarketDataService, yahooFinanceService)
 
    @Ignore("Fails, needs to be fixed")
    def "Validates GET batch returns stock information"() {
@@ -241,5 +246,19 @@ class StockControllerIT extends Specification {
 
       then: "We get an exception"
       thrown(IEXTradingException)
+   }
+
+   def "Validates GET yahooChart returns chart information"() {
+      given: "A stock symbol"
+      def symbol = "AAPL"
+      def range = "1d"
+      def interval = "1m"
+
+      when: "A call to the yahooChart endpoint is made"
+      def res = stockController.getYahooChart(symbol, range, interval)
+
+      then: "We get a valid chart object"
+      res.statusCode == HttpStatus.OK
+      res.getBody() != null
    }
 }


### PR DESCRIPTION
Implement Yahoo finance proxy for grap historical data

~~**READ BELOW**~~
~~I implemented 2 options to do this.~~
~~/chart1~~ /yahooChart uses a service/facade flow which looks clean and may be reused if we decide to get more data from yahoo finance.
~~/chart2 mirrors the request using a proxy. it is very short and simple.
Comments/Preferences?~~


# Related Issue
#266

# Proposed changes
- Add /yahooChart endpoint to the stockmarket controller
- Add yahoo service
- add yahoo facade

# Additional Info
- the endpoint esentially relays/proxy the response from https://query1.finance.yahoo.com/v8/finance/chart/{ticker}?range={range}&interval={interval}

# Checklist (if applicable)
- [x] Tests
- [x] Documentation

# Reviewer(s)
 - backend team
