### PR TITLE
#309: Add User Portfolio Over Time

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/controller/AlpacaController.java
+++ b/backend/src/main/java/com/capstone/moneytree/controller/AlpacaController.java
@@ -40,8 +40,8 @@ public class AlpacaController {
     *
     * @return ResponseEntity of Account.
     */
-   @GetMapping("/account")
-   public ResponseEntity<Account> getAccount(String userId) {
+   @GetMapping("/account/{userId}")
+   public ResponseEntity<Account> getAccount(@PathVariable(name = "userId") @Valid @NotBlank String userId) {
       Account account = marketInteractionsFacade.getAccount(userId);
 
       return ResponseEntity.ok(account);
@@ -52,8 +52,8 @@ public class AlpacaController {
     *
     * @return ResponseEntity of Position List.
     */
-   @GetMapping("/positions")
-   public ResponseEntity<List<Position>> getPositions(String userId) {
+   @GetMapping("/positions/{userId}")
+   public ResponseEntity<List<Position>> getPositions(@PathVariable(name = "userId") @Valid @NotBlank String userId) {
       List<Position> positions = marketInteractionsFacade.getOpenPositions(userId);
 
       return ResponseEntity.ok(positions);
@@ -70,7 +70,7 @@ public class AlpacaController {
     * @param extendedHours Includes extended hours in result. Works only for timeframe less than 1D.
     * @return A PortfolioHistory of timeseries
     */
-   @GetMapping("/portfolio/period={periodLength}&unit={periodUnit}&timeframe={timeFrame}&dateend={dateEnd}&extended={extendedHours}")
+   @GetMapping("/portfolio/userId={userId}&period={periodLength}&unit={periodUnit}&timeframe={timeFrame}&dateend={dateEnd}&extended={extendedHours}")
    public ResponseEntity<PortfolioHistory> getPortfolio(
            @PathVariable(name = "userId") @Valid @NotBlank String userId,
            @PathVariable(name = "periodLength") @Valid @NotBlank int periodLength,
@@ -90,6 +90,17 @@ public class AlpacaController {
    }
 
    /**
+    *  Gets the market status (open/closed).
+    *
+    * @return market status.
+    */
+   @GetMapping("/market-status/{userId}")
+   public ResponseEntity<Clock> getMarketClock(@PathVariable(name = "userId") @Valid @NotBlank String userId) {
+      Clock marketClock = marketInteractionsFacade.getMarketClock(userId);
+      return ResponseEntity.ok(marketClock);
+   }
+
+   /**
     * 1. To make a WS request, you must use a STOMP client with SockJS
     * 2. Endpoint to connect is "http://localhost:8080/api/v1/ws"
     * 3. Subscribe to the "/queue/user-{userId}" channel
@@ -106,16 +117,5 @@ public class AlpacaController {
    public void disconnectFromTradeUpdates(String userId) {
       marketInteractionsFacade.disconnectFromStream(userId);
    }
-
-   /**
-    *  Gets the market status (open/closed).
-    *
-    * @return market status.
-    */
-    @GetMapping("/market-status")
-    public ResponseEntity<Clock> getMarketClock(String userId) {
-      Clock marketClock = marketInteractionsFacade.getMarketClock(userId);
-      return ResponseEntity.ok(marketClock);
-    }
 }
 

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/AlpacaControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/AlpacaControllerTest.groovy
@@ -1,6 +1,16 @@
 package com.capstone.moneytree.controller
 
+import net.jacobpeterson.alpaca.AlpacaAPI
+import net.jacobpeterson.alpaca.enums.PortfolioPeriodUnit
+import net.jacobpeterson.alpaca.enums.PortfolioTimeFrame
+import net.jacobpeterson.domain.alpaca.account.Account
+import net.jacobpeterson.domain.alpaca.portfoliohistory.PortfolioHistory
+import net.jacobpeterson.domain.alpaca.position.Position
+import org.springframework.http.HttpStatus
+import org.springframework.http.ResponseEntity
 import org.springframework.test.context.ActiveProfiles
+
+import java.time.LocalDate
 
 import static com.capstone.moneytree.utils.MoneyTreeTestUtils.*
 
@@ -18,23 +28,81 @@ class AlpacaControllerTest extends Specification {
     private MarketInteractionsFacade marketInteractionsFacade
     private AlpacaController alpacaController
     private UserDao userDao
+    private AlpacaAPI alpacaAPI
 
     def setup() {
         userDao = Mock()
+        alpacaAPI = Mock()
         marketInteractionsFacade = new MarketInteractionsFacade(userDao)
         alpacaController = new AlpacaController(marketInteractionsFacade, messageSender)
     }
 
     @Test
+    def "It should get an Alpaca account"() {
+        given: "A user ID"
+        String userId = "59"
+        Account account = new Account()
+
+        and: "Mock the database and AlpacaAPI"
+        userDao.findUserById(Long.parseLong(userId)) >> createUser("test@money.ca", "user", "hello", "Yury", "Yes", "38rbb-sss")
+        alpacaAPI.getAccount() >> account
+
+        when: "Retrieving the account"
+        ResponseEntity<Account> response = alpacaController.getAccount(userId)
+
+        then: "Account is retrieved"
+        assert response.statusCode == HttpStatus.OK
+    }
+
+    @Test
+    def "Should retrieve the open positions"() {
+        given: "A user ID"
+        String userId = "10332"
+        List<Position> positions = new ArrayList<>()
+
+        and: "Mock the database and AlpacaAPI"
+        userDao.findUserById(Long.parseLong(userId)) >> createUser("test@money.ca", "user", "hello", "Yury", "Yes", "38rbb-sss")
+        alpacaAPI.getOpenPositions() >> positions
+
+        when: "Retrieving the positions"
+        ResponseEntity<List<Position>> response = alpacaController.getPositions(userId)
+
+        then: "Positions are retrieved"
+        assert response.statusCode == HttpStatus.OK
+    }
+
+    @Test
+    def "Should retrieve a portfolio"() {
+        given: "A user ID"
+        String userId = "10332"
+        int period = 1
+        String unit = "WEEK"
+        String timeFrame = "FIFTEEN_MINUTE"
+        LocalDate localDate = LocalDate.now()
+        String extended = "false"
+        PortfolioHistory portfolio = new PortfolioHistory()
+
+        and: "Mock the database and AlpacaAPI"
+        userDao.findUserById(Long.parseLong(userId)) >> createUser("test@money.ca", "user", "hello", "Yury", "Yes", "38rbb-sss")
+        alpacaAPI.getPortfolioHistory(period, PortfolioPeriodUnit.valueOf(unit), PortfolioTimeFrame.valueOf(timeFrame), localDate, extended as Boolean) >> portfolio
+
+        when: "Retrieving the clock"
+        ResponseEntity<PortfolioHistory> response = alpacaController.getPortfolio(userId, period, unit, timeFrame, localDate, extended)
+
+        then: "Account is retrieved"
+        assert response.statusCode == HttpStatus.OK
+    }
+
+    @Test
     def "It should listen to trade updates before sending an email when order completed"() {
         given: "A user (ID) subscribing to the trades"
-        String userId = "1";
+        String userId = "1"
 
         and: "Mock user"
         userDao.findUserById(Long.parseLong(userId)) >> createUser("test@money.ca", "user", "hello", "Yury", "Yes", "38rbb-sss")
 
         when: "Order is filled send an email"
-        alpacaController.registerToTradeUpdates(userId);
+        alpacaController.registerToTradeUpdates(userId)
 
         then: "No exception thrown"
     }
@@ -42,13 +110,13 @@ class AlpacaControllerTest extends Specification {
     @Test
     def "It should disconnect from trade updates when asked"() {
         given: "A user (ID) subscribing to the trades"
-        String userId = "1";
+        String userId = "1"
 
         and: "Mock user"
         userDao.findUserById(Long.parseLong(userId)) >> createUser("test@money.ca", "user", "hello", "Yury", "Yes", "38rbb-sss")
 
         when: "Order is filled send an email"
-        alpacaController.registerToTradeUpdates(userId);
+        alpacaController.registerToTradeUpdates(userId)
         Thread.sleep(2000)
         alpacaController.disconnectFromTradeUpdates(userId)
 

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/UserControllerIT.groovy
@@ -27,7 +27,6 @@ class UserControllerIT extends Specification {
     @Autowired
     private UserService userService
 
-
     @Autowired
     UserDao userDao
 


### PR DESCRIPTION
 
# Related Issue
- #309 

# Proposed changes
- Add the alpaca GET portfolio at `/api/alpaca/portfolio/userId={userId}&period={periodLength}&unit={periodUnit}&timeframe={timeFrame}&dateend={dateEnd}&extended={extendedHours}`
- More information on the query parameters [here](https://alpaca.markets/docs/api-documentation/api-v2/portfolio-history/). Also see the additional information
- Added Alpaca IT and Unit tests

# Additional Info
- User ID is a string
- Period length is an integer
- Period Unit is either D (day), W (week), month (M) or year (A)
- Time Frame is either 1Min, 5Min, 15Min, 1H or 1D
- DateEnd is a date in 'YYYY-MM-DD' format
- Extended hours is either 'true' or 'false'

# Checklist (if applicable)
- [x] Tests

# Reviewer(s)
 - @razine-bensari 
 - @EspressoCode 
 - @marwan-ayadi (for frontend)
