### PR TITLE
clean logs #242

### DIFF
--- a/backend/pom.xml
+++ b/backend/pom.xml
@@ -116,6 +116,7 @@
             <version>1.6.2</version>
             <scope>test</scope>
         </dependency>
+        <!-- Tests -->
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
@@ -139,28 +140,23 @@
             <version>3.0.6</version>
             <type>pom</type>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.codehaus.groovy</groupId>
+                    <artifactId>groovy-testng</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.springdoc</groupId>
             <artifactId>springdoc-openapi-ui</artifactId>
             <version>1.5.0</version>
-        </dependency>
-
-        <!-- // if you don't already have slf4j-api and an implementation of it in the classpath, add this! -->
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-simple</artifactId>
-            <version>1.7.30</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-api</artifactId>
         </dependency>
         <dependency>
             <groupId>com.github.razine-bensari</groupId>
@@ -188,11 +184,17 @@
             <artifactId>neo4j-harness</artifactId>
             <version>4.2.2</version>
             <scope>test</scope>
+            <exclusions>
+                <exclusion>
+                    <groupId>org.slf4j</groupId>
+                    <artifactId>slf4j-nop</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.jetbrains</groupId>
             <artifactId>annotations</artifactId>
-            <version>RELEASE</version>
+            <version>20.1.0</version>
             <scope>compile</scope>
         </dependency>
         <dependency>

--- a/backend/src/test/resources/application.yml
+++ b/backend/src/test/resources/application.yml
@@ -1,0 +1,3 @@
+spring:
+  main:
+    banner-mode: off

--- a/backend/src/test/resources/logback-test.xml
+++ b/backend/src/test/resources/logback-test.xml
@@ -1,0 +1,14 @@
+<configuration>
+
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <!-- encoders are assigned the type
+             ch.qos.logback.classic.encoder.PatternLayoutEncoder by default -->
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="off">
+        <appender-ref ref="STDOUT" />
+    </root>
+</configuration>


### PR DESCRIPTION
# Related Issue
- #242 

# Proposed changes
- org.jetbrains:annotations version warning
- org.slf4j multiple bindings warning
- testng excluded which caused error message and caused unit tests running to not show in console
- removed spring banner in integration tests
- set logs level to off to make dependencies logging disapear

# Additional Information
For debug purposes, you can set back the logging level in logback-test.xml to other levels such as debug or info. More documentation [here](http://logback.qos.ch/manual/configuration.html)

# Reviewer(s)
 - backend
