### PR TITLE
#325 revert back the removed code - edit profile BE

### DIFF
--- a/backend/src/test/groovy/com/capstone/moneytree/service/DefaultUserServiceTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/service/DefaultUserServiceTest.groovy
@@ -111,7 +111,7 @@ class DefaultUserServiceTest extends Specification {
         userDao.save() >> user
 
         when:
-        User userResponse = userService.editUserProfilePicture(user, image, "test")
+        User userResponse = userService.editUserProfilePicture(user, image, "avatarURL")
 
         then:
         userResponse != null


### PR DESCRIPTION
# Related Issue
- #325 

# Proposed changes
- Reverts the working code in DefaultUserService which was replaced by new code and caused the edit profile not to work properly
- Improved edit profile, by adding a new default cover photo to S3 and used it for when a new user is being created
- Fixed the failing backend test

# Additional Info
- I uploaded the new default cover photo and named it "COVER"+ the default profile picture name so that there would be no need to add a new env variable for that.


# Reviewer(s)
 - @DPigeon
