### PR TITLE
#346: Update Score When User Sell Stock

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/facade/MarketInteractionsFacade.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/MarketInteractionsFacade.java
@@ -221,7 +221,7 @@ public class MarketInteractionsFacade {
                   transaction = transactionDao.findByClientOrderId(clientOrderId);
                }
                String userIdForOrder = madeDao.findByTransactionId(transaction.getId()).getUser().getId().toString();
-               if (streamMessageType == AlpacaStreamMessageType.TRADE_UPDATES && updateTracker.get(clientOrderId)==false && userIdForOrder.equals(userId)
+               if (streamMessageType == AlpacaStreamMessageType.TRADE_UPDATES && !updateTracker.get(clientOrderId) && userIdForOrder.equals(userId)
                   ) {
                      messageSender.convertAndSend("/queue/user-" + userId,
                              tradeUpdate.getOrder().getClientOrderId());

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
@@ -152,7 +152,11 @@ public class DefaultTransactionService implements TransactionService {
                break;
             }
          }
-         calculateScoreAndUpdate(boughtPrice, transaction.getTotal(), user);
+
+         float soldPrice = transaction.getTotal();
+         if (boughtPrice != soldPrice) { // No need to update score if prices are the same
+            calculateScoreAndUpdate(boughtPrice, soldPrice, user);
+         }
       }
    }
 

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
@@ -7,7 +7,6 @@ import com.capstone.moneytree.dao.*;
 import com.capstone.moneytree.exception.AlpacaException;
 
 import com.capstone.moneytree.exception.EntityNotFoundException;
-import com.capstone.moneytree.model.relationship.Owns;
 import net.jacobpeterson.alpaca.enums.OrderSide;
 import net.jacobpeterson.alpaca.enums.OrderTimeInForce;
 
@@ -105,9 +104,8 @@ public class DefaultTransactionService implements TransactionService {
          LOGGER.info("Executed order {}", alpacaOrder.getClientOrderId());
 
          transaction = constructTransactionFromOrder(alpacaOrder);
-         transactionDao.save(transaction);
-
          updateUserScore(order, user, transaction);
+         transactionDao.save(transaction);
 
          /*
           * create and save two relationships: Made and ToFulfill. User Made Transaction

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
@@ -3,9 +3,11 @@ package com.capstone.moneytree.service.impl;
 import java.util.ArrayList;
 import java.util.List;
 
+import com.capstone.moneytree.dao.*;
 import com.capstone.moneytree.exception.AlpacaException;
 
 import com.capstone.moneytree.exception.EntityNotFoundException;
+import com.capstone.moneytree.model.relationship.Owns;
 import net.jacobpeterson.alpaca.enums.OrderSide;
 import net.jacobpeterson.alpaca.enums.OrderTimeInForce;
 
@@ -15,11 +17,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import com.capstone.moneytree.dao.StockDao;
-import com.capstone.moneytree.dao.TransactionDao;
-import com.capstone.moneytree.dao.UserDao;
-import com.capstone.moneytree.dao.MadeDao;
-import com.capstone.moneytree.dao.ToFulfillDao;
 import com.capstone.moneytree.facade.AlpacaSession;
 import com.capstone.moneytree.model.MoneyTreeOrderType;
 import com.capstone.moneytree.model.TransactionStatus;
@@ -98,7 +95,10 @@ public class DefaultTransactionService implements TransactionService {
          Stock stock = stockDao.findBySymbol(order.getSymbol());
          if (stock == null) { // if database does not have this stock object create and save it
             KeyStats stockInfo = stockMarketDataService.getKeyStats(order.getSymbol());
-            stock = Stock.builder().symbol(order.getSymbol()).companyName(stockInfo.getCompanyName()).build();
+            stock = Stock.builder()
+                    .symbol(order.getSymbol())
+                    .companyName(stockInfo.getCompanyName())
+                    .build();
             stockDao.save(stock);
          }
 
@@ -106,6 +106,8 @@ public class DefaultTransactionService implements TransactionService {
 
          transaction = constructTransactionFromOrder(alpacaOrder);
          transactionDao.save(transaction);
+
+         updateUserScore(order, user, transaction);
 
          /*
           * create and save two relationships: Made and ToFulfill. User Made Transaction
@@ -127,12 +129,39 @@ public class DefaultTransactionService implements TransactionService {
    }
 
    private Transaction constructTransactionFromOrder(Order alpacaOrder) {
-      return Transaction.builder().status(TransactionStatus.PENDING).purchasedAt(alpacaOrder.getCreatedAt())
+      return Transaction.builder()
+              .status(TransactionStatus.PENDING)
+              .purchasedAt(alpacaOrder.getCreatedAt())
               .clientOrderId(alpacaOrder.getClientOrderId())
               .moneyTreeOrderType(MoneyTreeOrderType
                       .valueOf(alpacaOrder.getType().toUpperCase() + "_" + alpacaOrder.getSide().toUpperCase()))
               .quantity(Float.parseFloat(alpacaOrder.getQty())).purchasedAt(alpacaOrder.getSubmittedAt())
-              .symbol(alpacaOrder.getSymbol()).build(); // avg price and total will be set only if stock got fulfilled
+              .symbol(alpacaOrder.getSymbol())
+              .build(); // avg price and total will be set only if stock got fulfilled
+   }
+
+   // ISSUE-346
+   public void updateUserScore(Order order, User user, Transaction transaction) {
+      if (order.getSide().equals("sell")) {
+         // TODO: Find the right stock bought with ids?
+         float boughtPrice = 0;
+         List<Made> userMade = madeDao.findByUserId(user.getId());
+         for (Made made : userMade) {
+            Transaction oldTransaction = made.getTransaction();
+            if (oldTransaction.getSymbol().equals(transaction.getSymbol())) {
+               boughtPrice = oldTransaction.getTotal();
+               break;
+            }
+         }
+
+         float soldPrice = transaction.getTotal();
+         if (boughtPrice < 1) {
+            double score = soldPrice - boughtPrice;
+            double updatedScore = user.getScore() + score;
+            user.setScore(updatedScore);
+            userDao.save(user);
+         }
+      }
    }
 
    @Override

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultTransactionService.java
@@ -143,7 +143,6 @@ public class DefaultTransactionService implements TransactionService {
    // ISSUE-346
    public void updateUserScore(Order order, User user, Transaction transaction) {
       if (order.getSide().equals("sell")) {
-         // TODO: Find the right stock bought with ids?
          float boughtPrice = 0;
          List<Made> userMade = madeDao.findByUserId(user.getId());
          for (Made made : userMade) {
@@ -153,14 +152,18 @@ public class DefaultTransactionService implements TransactionService {
                break;
             }
          }
+         calculateScoreAndUpdate(boughtPrice, transaction.getTotal(), user);
+      }
+   }
 
-         float soldPrice = transaction.getTotal();
-         if (boughtPrice < 1) {
-            double score = soldPrice - boughtPrice;
-            double updatedScore = user.getScore() + score;
-            user.setScore(updatedScore);
-            userDao.save(user);
-         }
+   private void calculateScoreAndUpdate(float boughtPrice, float soldPrice, User user) {
+      if (boughtPrice > 0) {
+         double score = soldPrice - boughtPrice;
+         double updatedScore = user.getScore() + score;
+         user.setScore(updatedScore);
+         userDao.save(user);
+      } else {
+         throw new EntityNotFoundException("Transaction not found while selling stock!");
       }
    }
 

--- a/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
+++ b/backend/src/main/java/com/capstone/moneytree/service/impl/DefaultUserService.java
@@ -125,6 +125,7 @@ public class DefaultUserService implements UserService {
         user.setPassword(encryptedPassword);
         user.setAvatarURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, DEFAULT_PROFILE_NAME));
         user.setCoverPhotoURL(String.format("https://%s.s3.amazonaws.com/%s", bucketName, "COVER-"  + DEFAULT_PROFILE_NAME));
+        user.setScore(0.0);
 
         userDao.save(user);
 

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
@@ -16,10 +16,10 @@ import net.jacobpeterson.alpaca.AlpacaAPI
 import net.jacobpeterson.alpaca.enums.OrderSide
 import net.jacobpeterson.alpaca.enums.OrderTimeInForce
 import net.jacobpeterson.domain.alpaca.order.Order
-import org.junit.Ignore
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
+import spock.lang.Ignore
 import spock.lang.Specification
 
 import java.time.ZonedDateTime

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
@@ -1,12 +1,21 @@
 package com.capstone.moneytree.controller
 
 import com.capstone.moneytree.dao.MadeDao
+import com.capstone.moneytree.dao.StockDao
+import com.capstone.moneytree.dao.ToFulfillDao
 import com.capstone.moneytree.dao.TransactionDao
 import com.capstone.moneytree.dao.UserDao
+import com.capstone.moneytree.facade.AlpacaSession
 import com.capstone.moneytree.model.TransactionStatus
+import com.capstone.moneytree.model.node.Stock
 import com.capstone.moneytree.model.node.Transaction
 import com.capstone.moneytree.model.node.User
 import com.capstone.moneytree.model.relationship.Made
+import com.capstone.moneytree.model.relationship.ToFulfill
+import net.jacobpeterson.alpaca.AlpacaAPI
+import net.jacobpeterson.alpaca.enums.OrderSide
+import net.jacobpeterson.alpaca.enums.OrderTimeInForce
+import net.jacobpeterson.domain.alpaca.order.Order
 import org.junit.Ignore
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.context.SpringBootTest
@@ -37,6 +46,14 @@ class TransactionControllerIT extends Specification {
     @Autowired
     MadeDao madeDao
 
+    @Autowired
+    StockDao stockDao
+
+    @Autowired
+    ToFulfillDao toFulfillDao
+
+    AlpacaSession alpacaSession = new AlpacaSession()
+
     def "Get all transactions in the database"() {
         setup: "Persist some transactions"
         String symbol1 = "AAPL"
@@ -59,10 +76,42 @@ class TransactionControllerIT extends Specification {
         transactionDao.delete(transaction2)
     }
 
-    // TODO: In another story since ISSUE-319 was too big
-    @Ignore("TODO")
+    // TODO: Fix in another story
+    @Ignore("Needs to be fixed")
     def "Execute a transaction in the database"() {
+        setup: "Persist a user and an order"
+        String symbol = "TSLA"
+        User user = createUser("test@test.com", "user", "pass", "Tester", "Yes", "545e5eee-7ee0-4b17-83db-a8cd95e0570e")
+        User persistedUser = userDao.save(user)
+        String userId = persistedUser.getId()
+        Order order = createOrder("1002333", symbol, "15", "market", "DAY")
+        order.setSide("buy")
 
+        and: "mock Alpaca API"
+        AlpacaAPI mockedAlpaca = Mock()
+        alpacaSession.alpaca(user.getAlpacaApiKey()) >> mockedAlpaca
+        mockedAlpaca.requestNewMarketOrder(order.getSymbol(), Integer.parseInt(order.getQty()),
+                OrderSide.valueOf(order.getSide().toUpperCase()), OrderTimeInForce.DAY) >> order
+
+        when: "Execute transaction"
+        List<Transaction> response = transactionController.executeTransaction(userId, order)
+
+        then: "The order should be executed with user updated"
+        response.get(0).getSymbol() == symbol
+        Transaction transaction = transactionDao.findByClientOrderId("1000000")
+        ToFulfill toFulfill = toFulfillDao.findByTransactionId(transaction.getId())
+        Made made = madeDao.findByTransactionId(transaction.getId())
+        Stock stock = stockDao.findBySymbol(order.getSymbol())
+        transaction.getSymbol() == symbol
+        made.getTransaction() == transaction
+        made.getUser() == user
+        toFulfill.getTransaction() == transaction
+
+        cleanup:
+        toFulfillDao.delete(toFulfill)
+        madeDao.delete(made)
+        transactionDao.delete(transaction)
+        stockDao.delete(stock)
     }
 
     def "Get user transactions in the database"() {

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
@@ -58,8 +58,8 @@ class TransactionControllerIT extends Specification {
         setup: "Persist some transactions"
         String symbol1 = "AAPL"
         String symbol2 = "TSLA"
-        Transaction transaction1 = createTransaction(symbol1, 10, 24, TransactionStatus.PENDING)
-        Transaction transaction2 = createTransaction(symbol2, 100, 75, TransactionStatus.COMPLETED)
+        Transaction transaction1 = createTransaction(symbol1, 10, 24, TransactionStatus.PENDING, 1)
+        Transaction transaction2 = createTransaction(symbol2, 100, 75, TransactionStatus.COMPLETED, 1)
         transactionDao.save(transaction1)
         transactionDao.save(transaction2)
 
@@ -120,8 +120,8 @@ class TransactionControllerIT extends Specification {
         User persistedUser = userDao.save(user)
         String symbol1 = "AAPL"
         String symbol2 = "TSLA"
-        Transaction transaction1 = createTransaction(symbol1, 100, 24, TransactionStatus.PENDING)
-        Transaction transaction2 = createTransaction(symbol2, 110, 4, TransactionStatus.PENDING)
+        Transaction transaction1 = createTransaction(symbol1, 100, 24, TransactionStatus.PENDING, 1)
+        Transaction transaction2 = createTransaction(symbol2, 110, 4, TransactionStatus.PENDING, 1)
         transactionDao.save(transaction1)
         transactionDao.save(transaction2)
         Made made1 = createMadeRelationship(persistedUser, transaction1, ZonedDateTime.now())

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerIT.groovy
@@ -76,7 +76,7 @@ class TransactionControllerIT extends Specification {
         transactionDao.delete(transaction2)
     }
 
-    // TODO: Fix in another story
+    // TODO: Needs to be fixed in another story
     @Ignore("Needs to be fixed")
     def "Execute a transaction in the database"() {
         setup: "Persist a user and an order"

--- a/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/controller/TransactionControllerTest.groovy
@@ -1,7 +1,6 @@
 package com.capstone.moneytree.controller
 
 import com.capstone.moneytree.dao.StockDao
-import com.capstone.moneytree.model.node.Stock
 import com.capstone.moneytree.model.node.Transaction
 import com.capstone.moneytree.service.impl.DefaultTransactionService
 

--- a/backend/src/test/groovy/com/capstone/moneytree/service/DefaultTransactionServiceTest.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/service/DefaultTransactionServiceTest.groovy
@@ -176,18 +176,29 @@ class DefaultTransactionServiceTest extends Specification {
     def "Should update user score properly with positive score"() {
         given: "A user with an order and an old transaction executed"
         String symbol = "TSLA"
-        float boughtPrice = 10
+        float price1 = 10
+        float price2 = 20
+        float price3 = 5
+        float qty1 = 5
+        float qty2 = 3
+        float qty3 = 1
+        float boughtPrice = 13
         float soldPrice = 40
         double initialScore = 20
-        double finalScore = 50
+        double finalScore = initialScore + soldPrice - boughtPrice
         User user = createUser("test@test.com", "user", "pass", "User", "Name", "key")
         user.setId(10)
         user.setScore(initialScore)
         Order order = createOrder("1", symbol, "10", "market", "DAY");
         order.setSide("sell")
-        Transaction oldTransaction = createTransaction(symbol, 15, boughtPrice, TransactionStatus.COMPLETED)
-        List<Made> madeList = List.of(createMadeRelationship(user, oldTransaction, ZonedDateTime.now()))
-        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED)
+        Transaction transaction1 = createTransaction(symbol, 15, price1, TransactionStatus.COMPLETED, qty1)
+        Transaction transaction2 = createTransaction(symbol, 15, price2, TransactionStatus.COMPLETED, qty2)
+        Transaction transaction3 = createTransaction(symbol, 15, price3, TransactionStatus.COMPLETED, qty3)
+        List<Made> madeList = List.of(
+                createMadeRelationship(user, transaction1, ZonedDateTime.now()),
+                createMadeRelationship(user, transaction2, ZonedDateTime.now()),
+                createMadeRelationship(user, transaction3, ZonedDateTime.now()))
+        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED, 1)
 
         and: "mock database"
         madeDao.findByUserId(user.getId()) >> madeList
@@ -199,8 +210,7 @@ class DefaultTransactionServiceTest extends Specification {
         when: "Updating a user's score"
         transactionService.updateUserScore(order, user, currentTransaction)
 
-        then: "User should have made +30 points"
-        user.getScore() == initialScore + (soldPrice - boughtPrice)
+        then: "User should have made +27 points"
         user.getScore() == finalScore
     }
 
@@ -216,9 +226,9 @@ class DefaultTransactionServiceTest extends Specification {
         user.setScore(initialScore)
         Order order = createOrder("1", symbol, "10", "market", "DAY");
         order.setSide("sell")
-        Transaction oldTransaction = createTransaction(symbol, 15, boughtPrice, TransactionStatus.COMPLETED)
-        List<Made> madeList = List.of(createMadeRelationship(user, oldTransaction, ZonedDateTime.now()))
-        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED)
+        Transaction transaction = createTransaction(symbol, 15, boughtPrice, TransactionStatus.COMPLETED, 1)
+        List<Made> madeList = List.of(createMadeRelationship(user, transaction, ZonedDateTime.now()))
+        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED, 1)
 
         and: "mock database"
         madeDao.findByUserId(user.getId()) >> madeList
@@ -238,18 +248,29 @@ class DefaultTransactionServiceTest extends Specification {
     def "Should update user score properly with negative score"() {
         given: "A user with an order and an old transaction executed"
         String symbol = "TSLA"
-        float boughtPrice = 50
-        float soldPrice = 10
+        float price1 = 10
+        float price2 = 20
+        float price3 = 5
+        float qty1 = 5
+        float qty2 = 3
+        float qty3 = 1
+        float boughtPrice = 13
+        float soldPrice = 1
         double initialScore = 10
-        double finalScore = -30
+        double finalScore = initialScore + soldPrice - boughtPrice
         User user = createUser("test@test.com", "user", "pass", "User", "Name", "key")
         user.setId(10)
         user.setScore(initialScore)
         Order order = createOrder("1", symbol, "10", "market", "DAY");
         order.setSide("sell")
-        Transaction oldTransaction = createTransaction(symbol, 15, boughtPrice, TransactionStatus.COMPLETED)
-        List<Made> madeList = List.of(createMadeRelationship(user, oldTransaction, ZonedDateTime.now()))
-        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED)
+        Transaction transaction1 = createTransaction(symbol, 15, price1, TransactionStatus.COMPLETED, qty1)
+        Transaction transaction2 = createTransaction(symbol, 15, price2, TransactionStatus.COMPLETED, qty2)
+        Transaction transaction3 = createTransaction(symbol, 15, price3, TransactionStatus.COMPLETED, qty3)
+        List<Made> madeList = List.of(
+                createMadeRelationship(user, transaction1, ZonedDateTime.now()),
+                createMadeRelationship(user, transaction2, ZonedDateTime.now()),
+                createMadeRelationship(user, transaction3, ZonedDateTime.now()))
+        Transaction currentTransaction = createTransaction(symbol, 15, soldPrice, TransactionStatus.COMPLETED, 1)
 
         and: "mock database"
         madeDao.findByUserId(user.getId()) >> madeList
@@ -261,8 +282,7 @@ class DefaultTransactionServiceTest extends Specification {
         when: "Updating a user's score"
         transactionService.updateUserScore(order, user, currentTransaction)
 
-        then: "User should have made -30 points"
-        user.getScore() == initialScore + (soldPrice - boughtPrice)
+        then: "User should have made -12 points"
         user.getScore() == finalScore
     }
 
@@ -273,7 +293,7 @@ class DefaultTransactionServiceTest extends Specification {
         user.setId(5)
         Order order = createOrder("1", symbol, "10", "market", "DAY");
         order.setSide("buy")
-        Transaction currentTransaction = createTransaction(symbol, 15, 15, TransactionStatus.COMPLETED)
+        Transaction currentTransaction = createTransaction(symbol, 15, 15, TransactionStatus.COMPLETED, 1)
 
         when: "Updating a user's score"
         transactionService.updateUserScore(order, user, currentTransaction)
@@ -294,9 +314,9 @@ class DefaultTransactionServiceTest extends Specification {
         user.setScore(initialScore)
         Order order = createOrder("1", symbol1, "10", "market", "DAY");
         order.setSide("sell")
-        Transaction oldTransaction = createTransaction(symbol1, 15, boughtPrice, TransactionStatus.COMPLETED)
-        List<Made> madeList = List.of(createMadeRelationship(user, oldTransaction, ZonedDateTime.now()))
-        Transaction currentTransaction = createTransaction(symbol2, 15, soldPrice, TransactionStatus.COMPLETED)
+        Transaction transaction = createTransaction(symbol1, 15, boughtPrice, TransactionStatus.COMPLETED, 1)
+        List<Made> madeList = List.of(createMadeRelationship(user, transaction, ZonedDateTime.now()))
+        Transaction currentTransaction = createTransaction(symbol2, 15, soldPrice, TransactionStatus.COMPLETED, 1)
 
         and: "mock database"
         madeDao.findByUserId(user.getId()) >> madeList

--- a/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
@@ -59,12 +59,13 @@ class MoneyTreeTestUtils {
               null, null, null, null, null)
    }
 
-   static Transaction createTransaction(String symbol, float avgPrice, float total, TransactionStatus status) {
+   static Transaction createTransaction(String symbol, float avgPrice, float total, TransactionStatus status, float qty) {
       return Transaction.builder()
                .symbol(symbol)
                .avgPrice(avgPrice)
                .total(total)
                .status(status)
+               .quantity(qty)
                .build()
    }
 

--- a/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
+++ b/backend/src/test/groovy/com/capstone/moneytree/utils/MoneyTreeTestUtils.groovy
@@ -53,7 +53,7 @@ class MoneyTreeTestUtils {
    }
 
    static Order createOrder(String id, String symbol, String qty, String type, String timeInForce) {
-      return new Order(id, null, null, null, null, null, null,
+      return new Order(id, "1000000", ZonedDateTime.now(), ZonedDateTime.now(), ZonedDateTime.now(), ZonedDateTime.now(), null,
               null, null, null, null, null, null, symbol, null,
               qty, null, type, null, timeInForce, null, null, null, null,
               null, null, null, null, null)


### PR DESCRIPTION
 
# Related Issue
- #346 

# Proposed changes
- User's score defaults to 0 when registered
- Updating and calculating the user's score when a transaction is processed
- Added 6 tests for all possible paths

# Additional Info
- A user will have its score updated if a transaction bought with the same symbol is found within the database. Then, the score will be nevative or positive depending on its performance in selling. If sold at $40 but bought at $10, +30 points. If sold at $20 but bought at $60, -40 points.

# Checklist (if applicable)
- [x] Tests

# Reviewer(s)
 - BackendTeam
