### PR TITLE
#378 added api types to alpaca.properties

### DIFF
--- a/backend/src/main/java/com/capstone/moneytree/facade/AlpacaSession.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/AlpacaSession.java
@@ -2,6 +2,9 @@ package com.capstone.moneytree.facade;
 
 
 import com.capstone.moneytree.handler.ExceptionMessage;
+import net.jacobpeterson.alpaca.enums.api.DataAPIType;
+import net.jacobpeterson.alpaca.enums.api.EndpointAPIType;
+import net.jacobpeterson.alpaca.properties.AlpacaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
@@ -25,12 +28,11 @@ public class AlpacaSession {
     * @return the alpaca client
     */
    public AlpacaAPI alpaca(String userId, String alpacaKey) {
-      LOGGER.info("Test for key: {}", alpacaKey);
       if (alpacaKey.isBlank()) {
          LOGGER.error(ExceptionMessage.ALPACA_TOKEN_BLANK.getMessage());
          throw new BadRequestException(ExceptionMessage.ALPACA_TOKEN_BLANK.getMessage());
       }
       LOGGER.info("Creating an Alpaca Session to user ID {}", userId);
-      return new AlpacaAPI(alpacaKey);
+      return new AlpacaAPI(null, null, alpacaKey, EndpointAPIType.PAPER, DataAPIType.IEX);
    }
 }

--- a/backend/src/main/java/com/capstone/moneytree/facade/AlpacaSession.java
+++ b/backend/src/main/java/com/capstone/moneytree/facade/AlpacaSession.java
@@ -4,7 +4,6 @@ package com.capstone.moneytree.facade;
 import com.capstone.moneytree.handler.ExceptionMessage;
 import net.jacobpeterson.alpaca.enums.api.DataAPIType;
 import net.jacobpeterson.alpaca.enums.api.EndpointAPIType;
-import net.jacobpeterson.alpaca.properties.AlpacaProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -20,8 +20,8 @@ alpaca.key.id=${ALPACA_KEY_ID}
 alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
-endpoint_api_type =paper
-data_api_type =iex
+endpoint_api_type=paper
+data_api_type=iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_SANDBOX}

--- a/backend/src/main/resources/application-dev.properties
+++ b/backend/src/main/resources/application-dev.properties
@@ -20,6 +20,8 @@ alpaca.key.id=${ALPACA_KEY_ID}
 alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
+endpoint_api_type =paper
+data_api_type =iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_SANDBOX}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -20,8 +20,8 @@ alpaca.key.id=${ALPACA_KEY_ID}
 alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
-endpoint_api_type =paper
-data_api_type =iex
+endpoint_api_type=paper
+data_api_type=iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_PROD}

--- a/backend/src/main/resources/application-prod.properties
+++ b/backend/src/main/resources/application-prod.properties
@@ -20,6 +20,8 @@ alpaca.key.id=${ALPACA_KEY_ID}
 alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
+endpoint_api_type =paper
+data_api_type =iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_PROD}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,6 +18,8 @@ alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.testToken=123456
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
+endpoint_api_type =paper
+data_api_type =iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_SANDBOX}

--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -18,8 +18,8 @@ alpaca.secret=${ALPACA_SECRET_ID}
 alpaca.testToken=123456
 alpaca.base.api.url=https://paper-api.alpaca.markets
 alpaca.base.data.url=https://data.alpaca.markets
-endpoint_api_type =paper
-data_api_type =iex
+endpoint_api_type=paper
+data_api_type=iex
 
 # IEXCloud related properties
 IEXCloud.publishable.token=${IEXCLOUD_PUBLISHABLE_TOKEN_SANDBOX}


### PR DESCRIPTION
 
# Related Issue
- bug fix for #378

# Proposed changes
- added alpaca API types to properties

# Additional Info
- Based on the backend log on error on Digital Ocean:

![Capture1](https://user-images.githubusercontent.com/33170291/113545247-ad4fed80-959e-11eb-9429-30be0c4930ad.PNG)

We have a null pointer error while we want to create the Alpaca session, but this is not about the null key, because as you can see, we are passing line 148 which means our key, secret or oAuth token is fine.

![errrr](https://user-images.githubusercontent.com/33170291/113545879-d624b280-959f-11eb-8050-1941e8e22605.PNG)

Line 149 is the problematic part which is complaining about API type, I added the 2 required API types in our properties files (based on https://github.com/Petersoj/alpaca-java#Configuration ). I hope by merging this maybe we get rid of that error.

@DPigeon And I don't understand why we don't have this issue on our local.

@DPigeon 